### PR TITLE
Don't return null in onbeforeunload

### DIFF
--- a/leaflet/static/leaflet/leaflet.forms.js
+++ b/leaflet/static/leaflet/leaflet.forms.js
@@ -82,7 +82,6 @@ L.GeometryField = L.Class.extend({
                 return L.GeometryField.unsavedText;
             if (typeof(_beforeunload) == 'function')
                 return _beforeunload();
-            return null;
         }, this);
     },
 


### PR DESCRIPTION
Internet Explorer will always ask you if you want to leave the page if "null" is returned. See:

http://stackoverflow.com/questions/11793996/onbeforeunload-handler-says-null-in-ie
