### PR TITLE
expose Leaflet.draw control after its initialized

### DIFF
--- a/leaflet/static/leaflet/leaflet.extras.js
+++ b/leaflet/static/leaflet/leaflet.extras.js
@@ -199,6 +199,10 @@ L.Map.djangoMap = function (id, options) {
     if (typeof(options.callback) == 'function') {
         setTimeout(function () {
             options.callback(map, options);
+            /*
+             * Trigger custom map:aftercallback Event
+             */
+            triggerEvent(window, 'map:aftercallback', {map: map, options: options});
         }, 0);
     }
 

--- a/leaflet/static/leaflet/leaflet.forms.js
+++ b/leaflet/static/leaflet/leaflet.forms.js
@@ -113,6 +113,7 @@ L.GeometryField = L.Class.extend({
             }, this);
         }
 
+        this._drawControl = drawControl;
         this.load();
     },
 

--- a/leaflet/templates/leaflet/widget.html
+++ b/leaflet/templates/leaflet/widget.html
@@ -16,7 +16,8 @@
 
     function {{ id_map_callback }}(map, options) {
         {{ module }}.store_class = {{ field_store_class }};
-        (new {{ geometry_field_class}}({{ module }})).addTo(map);
+        {{ module }}.geometry_field = new {{ geometry_field_class}}({{ module }});
+        {{ module }}.geometry_field.addTo(map);
         {% block callback %}{% endblock callback %}
     };
 </script>


### PR DESCRIPTION
(resolves issue#44) I do it in most straightforward way I could see.
Save L.GeometryField into geodjango widget variable as geodjango_geometry.geometry_field
Save Leaflet.draw instance as L.GeometryField._drawControl 

Because 'map:init' event is triggered before the the draw control is saved, the most straightfarward way to do stuff that depends on draw control or other callback things, seems to me to generate 'map:aftercallback' custom event. 

So, use case is this:

```
$(window).on("map:aftercallback", function (e) {
    var detail = e.originalEvent ?
                 e.originalEvent.detail : e.detail;
    var drawControl = geodjango_geometry.geometry_field._drawControl;
    drawControl.setDrawingOptions({
        polygon: {
            allowIntersection: false,
            showArea: true
        },
        rectangle: {
            repeatMode: false
        }
    });
});
```

I am not sure if this is the best way, but it gets the job done for me, and it might help someone else.
