### PR TITLE
fix: python 2.6 compatibility (ordereddict)

### DIFF
--- a/leaflet/__init__.py
+++ b/leaflet/__init__.py
@@ -1,7 +1,12 @@
 # -*- coding: utf8 -*-
 import urlparse
 import warnings
-from collections import OrderedDict
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    # python 2.6 compatibility (need to install ordereddict package).
+    from ordereddict import OrderedDict
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,12 @@
 import os
 from setuptools import setup, find_packages
+import sys
 
 here = os.path.abspath(os.path.dirname(__file__))
+
+requires = ['Django']
+if sys.version_info < (2, 7):
+    requires += ['ordereddict']
 
 setup(
     name='django-leaflet',
@@ -14,7 +19,7 @@ setup(
     long_description=open(os.path.join(here, 'README.rst')).read() + '\n\n' + 
                      open(os.path.join(here, 'CHANGES')).read(),
     license='LPGL, see LICENSE file.',
-    install_requires=['Django'],
+    install_requires=requires,
     packages=find_packages(),
     include_package_data = True,
     zip_safe = False,


### PR DESCRIPTION
Commit bfcbc0839b8609d9ab7c68fd42da41fa6092232d broke python 2.6 compatibility. Here is the fix.
