### PR TITLE
Make django-leaflet work without libgeos (fixes #65)

### DIFF
--- a/leaflet/admin.py
+++ b/leaflet/admin.py
@@ -9,10 +9,10 @@ except ImportError:
     GeoJSONField = type(object)
 try:
     from django.contrib.gis.db.models import GeometryField
-    from .forms.widgets import LeafletWidget
 except ImportError:
     GeometryField = type(object)
-    from django.forms.widgets import Textarea as LeafletWidget
+
+from .forms.widgets import LeafletWidget
 
 
 class LeafletGeoAdmin(ModelAdmin):

--- a/leaflet/forms/backport.py
+++ b/leaflet/forms/backport.py
@@ -34,7 +34,6 @@ import warnings
 
 from django.conf import settings
 from django.contrib.gis import gdal
-from django.contrib.gis.geos import GEOSGeometry, GEOSException
 from django.forms.widgets import Widget
 from django.template import loader
 from django.utils import six
@@ -42,6 +41,16 @@ from django.utils import translation
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 from django.core import validators
+
+try:
+    from django.contrib.gis.geos import GEOSGeometry
+except ImportError:
+    from .nogeos import GEOSGeometry
+
+try:
+    from django.contrib.gis.geos import GEOSException
+except ImportError:
+    from .nogeos import GEOSException
 
 logger = logging.getLogger('django.contrib.gis')
 

--- a/leaflet/forms/nogeos.py
+++ b/leaflet/forms/nogeos.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+
+class GEOSGeometry(object):
+    """
+    A simple mock of django.contrib.gis.geos.GEOSGeometry to make
+    django-leaflet work with only django-geojson (without libgeos)
+    """
+    def __init__(self, geo_input, srid=None):
+        self.srid = srid
+        self.geojson = geo_input
+        return
+
+
+class GEOSException(Exception):
+    pass


### PR DESCRIPTION
Mainly, adds a simple no-op mock of GEOSGeometry when libgeos is not installed.
