### PR TITLE
make the only layer match the map max/min_zoom

### DIFF
--- a/leaflet/static/leaflet/leaflet.extras.js
+++ b/leaflet/static/leaflet/leaflet.extras.js
@@ -105,6 +105,11 @@ L.Map.DjangoMap = L.Map.extend({
 
         if (layers.length == 1) {
             var layer = l2d(layers[0]);
+            // make the only layer match the map max/min_zoom
+            layer.options = L.Util.extend(layer.options, {
+            			'minZoom': this.options['minZoom'],
+            			'maxZoom': this.options['maxZoom']
+            		});
             L.tileLayer(layer.url, layer.options).addTo(this);
             return;
         }


### PR DESCRIPTION
Hi, this fixes the max/min_zoom issue for the single layer case, which is pretty clear.
