### PR TITLE
revert MIN_ZOOM default value to 0

### DIFF
--- a/leaflet/__init__.py
+++ b/leaflet/__init__.py
@@ -30,7 +30,7 @@ app_settings = dict({
     'ATTRIBUTION_PREFIX': None,
     'SPATIAL_EXTENT': None,
     'DEFAULT_ZOOM': None,
-    'MIN_ZOOM': None,
+    'MIN_ZOOM': 0,
     'MAX_ZOOM': None,
     'DEFAULT_CENTER': None,
     'SRID': None,


### PR DESCRIPTION
I'm getting this error for points geometries:
```
Uncaught Error: Invalid LatLng object: (NaN, NaN) 
```
after this commit: https://github.com/makinacorpus/django-leaflet/commit/c84a9a6c1c22d86690f110cc09243055415cfae6

"minzoom" is set anyway, probably with undefined, and likely causing the error in Leaflet:
https://github.com/makinacorpus/django-leaflet/blob/master/leaflet/static/leaflet/leaflet.extras.js#L49
