### PR TITLE
deal with filename altering by e.g. django-compressor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -276,6 +276,21 @@ and no longer adds map objects into ``window.maps`` array by default. To restore
 
     'NO_GLOBALS' = False
 
+Manually specify image path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If you are using staticfiles compression libraries such as django_compressor,
+which can do any of compressing, concatenating or renaming javascript files.
+This may break Leaflet's own ability to determine its installed path, and in
+turn it will break the method ``L.Icon.Default.imagePath()``.
+
+To use Django's own knowledge of its static files to set this value manually,
+use::
+
+    'SET_IMAGE_PATH_MANUALLY': True
+
+This will append to the output html::
+
+    L.Icon.Default.imagePath = "{% static "leaflet/images" %}";
 
 Plugins
 ~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -286,7 +286,7 @@ turn it will break the method ``L.Icon.Default.imagePath()``.
 To use Django's own knowledge of its static files to set this value manually,
 use::
 
-    'SET_IMAGE_PATH_MANUALLY': True
+    'FORCE_IMAGE_PATH': True
 
 This will append to the output html::
 

--- a/README.rst
+++ b/README.rst
@@ -276,21 +276,17 @@ and no longer adds map objects into ``window.maps`` array by default. To restore
 
     'NO_GLOBALS' = False
 
-Manually specify image path
+Force Leaflet image path
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If you are using staticfiles compression libraries such as django_compressor,
 which can do any of compressing, concatenating or renaming javascript files.
 This may break Leaflet's own ability to determine its installed path, and in
 turn it will break the method ``L.Icon.Default.imagePath()``.
 
-To use Django's own knowledge of its static files to set this value manually,
-use::
+To use Django's own knowledge of its static files to force this value
+explicitly, use::
 
     'FORCE_IMAGE_PATH': True
-
-This will append to the output html::
-
-    L.Icon.Default.imagePath = "{% static "leaflet/images" %}";
 
 Plugins
 ~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -279,9 +279,9 @@ and no longer adds map objects into ``window.maps`` array by default. To restore
 Force Leaflet image path
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If you are using staticfiles compression libraries such as django_compressor,
-which can do any of compressing, concatenating or renaming javascript files.
-This may break Leaflet's own ability to determine its installed path, and in
-turn it will break the method ``L.Icon.Default.imagePath()``.
+which can do any of compressing, concatenating or renaming javascript files,
+this may break Leaflet's own ability to determine its installed path, and in
+turn break the method ``L.Icon.Default.imagePath()``.
 
 To use Django's own knowledge of its static files to force this value
 explicitly, use::

--- a/leaflet/templates/leaflet/js.html
+++ b/leaflet/templates/leaflet/js.html
@@ -20,7 +20,7 @@
     {% if with_forms %}{% include "leaflet/_leaflet_draw_i18n.js" %}{% endif %}
     L.Control.ResetView.TITLE = "{% trans "Reset view" %}";
     L.Control.ResetView.ICON = "url({% static "leaflet/images/reset-view.png" %})";
-    {% if SET_IMAGE_PATH_MANUALLY %}
+    {% if FORCE_IMAGE_PATH %}
     L.Icon.Default.imagePath = "{% static "leaflet/images" %}";
     {% endif %}
 </script>

--- a/leaflet/templates/leaflet/js.html
+++ b/leaflet/templates/leaflet/js.html
@@ -20,4 +20,7 @@
     {% if with_forms %}{% include "leaflet/_leaflet_draw_i18n.js" %}{% endif %}
     L.Control.ResetView.TITLE = "{% trans "Reset view" %}";
     L.Control.ResetView.ICON = "url({% static "leaflet/images/reset-view.png" %})";
+    {% if SET_IMAGE_PATH_MANUALLY %}
+    L.Icon.Default.imagePath = "{% static "leaflet/images" %}";
+    {% endif %}
 </script>

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -38,11 +38,13 @@ def leaflet_js(plugins=None):
     """
     plugin_names = _get_plugin_names(plugins)
     with_forms = PLUGIN_FORMS in plugin_names or PLUGIN_ALL in plugin_names
+    SET_IMAGE_PATH_MANUALLY = app_settings.get('SET_IMAGE_PATH_MANUALLY')
     return {
         "DEBUG": settings.TEMPLATE_DEBUG,
         "SRID": str(SRID) if SRID else None,
         "PLUGINS_JS": _get_all_resources_for_plugins(plugin_names, 'js'),
-        "with_forms": with_forms
+        "with_forms": with_forms,
+        "SET_IMAGE_PATH_MANUALLY": SET_IMAGE_PATH_MANUALLY
     }
 
 

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -38,13 +38,13 @@ def leaflet_js(plugins=None):
     """
     plugin_names = _get_plugin_names(plugins)
     with_forms = PLUGIN_FORMS in plugin_names or PLUGIN_ALL in plugin_names
-    SET_IMAGE_PATH_MANUALLY = app_settings.get('SET_IMAGE_PATH_MANUALLY')
+    FORCE_IMAGE_PATH = app_settings.get('FORCE_IMAGE_PATH')
     return {
         "DEBUG": settings.TEMPLATE_DEBUG,
         "SRID": str(SRID) if SRID else None,
         "PLUGINS_JS": _get_all_resources_for_plugins(plugin_names, 'js'),
         "with_forms": with_forms,
-        "SET_IMAGE_PATH_MANUALLY": SET_IMAGE_PATH_MANUALLY
+        "FORCE_IMAGE_PATH": FORCE_IMAGE_PATH
     }
 
 


### PR DESCRIPTION
django-compressor, with the compression option turned on, renames included js files. This means that Leaflet can't use its own filename to determine the path to image files, see https://github.com/Leaflet/Leaflet/blob/5a518194945813f4b578861799f23a94248b553e/src/layer/marker/Icon.Default.js#L23-L25.

This edit adds a settings option `SET_IMAGE_PATH_MANUALLY`, which will cause the file path to be written manually at the end of the generated js includes:

``` js
L.Icon.Default.imagePath = "{% static "leaflet/images" %}";
```
