### PR TITLE
Update leaflet.forms.js

### DIFF
--- a/leaflet/static/leaflet/leaflet.forms.js
+++ b/leaflet/static/leaflet/leaflet.forms.js
@@ -167,7 +167,11 @@ L.GeometryField = L.Class.extend({
     _setView: function () {
         // Change view extent
         if (this.drawnItems.getLayers().length > 0) {
-            this._map.fitBounds(this.drawnItems.getBounds());
+            var bounds = this.drawnItems.getBounds();
+            if (!bounds._southWest.equals(bounds._northEast))
+                this._map.fitBounds(bounds);
+            else
+                this._map.setView(bounds._northEast, this.default_zoom);
         }
         // Else keep view extent set by django-leaflet template tag
     },


### PR DESCRIPTION
Might be a solution for this issue: https://github.com/makinacorpus/django-leaflet/issues/90
The problem is that when you use widget with PointField calling `this.drawnItems.getBounds()` will give you a `LatLngBounds` object with equal `_northEast` and `_southWest` properties. This freezes browser.
The following solution solves this error by centering map to given position.
