### PR TITLE
Move the GeoAdmin to a Mixin to allow inlines use (fix #60)

### DIFF
--- a/leaflet/admin.py
+++ b/leaflet/admin.py
@@ -17,7 +17,7 @@ except (ImportError, ImproperlyConfigured):
 from .forms.widgets import LeafletWidget
 
 
-class LeafletGeoAdmin(ModelAdmin):
+class LeafletGeoAdminMixin(object):
     widget = LeafletWidget
     map_template = 'leaflet/admin/widget.html'
     modifiable = True
@@ -40,7 +40,7 @@ class LeafletGeoAdmin(ModelAdmin):
             kwargs['widget'] = self._get_map_widget(db_field)
             return db_field.formfield(**kwargs)
         else:
-            return super(LeafletGeoAdmin, self).formfield_for_dbfield(db_field, **kwargs)
+            return super(LeafletGeoAdminMixin, self).formfield_for_dbfield(db_field, **kwargs)
 
     def _get_map_widget(self, db_field):
         """
@@ -55,3 +55,7 @@ class LeafletGeoAdmin(ModelAdmin):
             map_height = self.map_height
             display_raw = self.display_raw
         return LeafletMap
+
+
+class LeafletGeoAdmin(LeafletGeoAdminMixin, ModelAdmin):
+    pass


### PR DESCRIPTION
A simple fix to #60.

Usage for inlines is:

```python
class PoiLocationInline(LeafletGeoAdminMixin, admin.StackedInline):
    model = PoiLocation
```

Depending on the maintainer's view on this, I can update the doc before merging. Maybe also create utility subclasses like `LeafletGeoStackedInline` and `LeafletGeoTabularInline`.