### PR TITLE
TEMPLATE_DEBUG has been deprecated in django 1.8

### DIFF
--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -41,7 +41,7 @@ def leaflet_js(plugins=None):
     with_forms = PLUGIN_FORMS in plugin_names or PLUGIN_ALL in plugin_names
     FORCE_IMAGE_PATH = app_settings.get('FORCE_IMAGE_PATH')
 
-    if hasattr(settings,'TEMPLATE_DEBUG'):
+    if hasattr(settings, 'TEMPLATE_DEBUG'):
         debug = settings.TEMPLATE_DEBUG
     elif 'debug' in settings.TEMPLATES[0]['OPTIONS']:
         debug = settings.TEMPLATES[0]['OPTIONS']['debug']

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -40,8 +40,15 @@ def leaflet_js(plugins=None):
     plugin_names = _get_plugin_names(plugins)
     with_forms = PLUGIN_FORMS in plugin_names or PLUGIN_ALL in plugin_names
     FORCE_IMAGE_PATH = app_settings.get('FORCE_IMAGE_PATH')
+    try:
+        debug = settings.TEMPLATE_DEBUG
+    except AttributeError:
+        try:
+            debug = settings.TEMPLATES[0]['OPTIONS']['debug']
+        except KeyError:
+            debug = False
     return {
-        "DEBUG": settings.TEMPLATE_DEBUG,
+        "DEBUG": debug,
         "SRID": str(SRID) if SRID else None,
         "PLUGINS_JS": _get_all_resources_for_plugins(plugin_names, 'js'),
         "with_forms": with_forms,

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -40,13 +40,14 @@ def leaflet_js(plugins=None):
     plugin_names = _get_plugin_names(plugins)
     with_forms = PLUGIN_FORMS in plugin_names or PLUGIN_ALL in plugin_names
     FORCE_IMAGE_PATH = app_settings.get('FORCE_IMAGE_PATH')
+
     if hasattr(settings,'TEMPLATE_DEBUG'):
         debug = settings.TEMPLATE_DEBUG
+    elif 'debug' in settings.TEMPLATES[0]['OPTIONS']:
+        debug = settings.TEMPLATES[0]['OPTIONS']['debug']
     else:
-        if 'debug' in settings.TEMPLATES[0]['OPTIONS']:
-            debug = settings.TEMPLATES[0]['OPTIONS']['debug']
-        else:
-            debug = False
+        debug = False
+
     return {
         "DEBUG": debug,
         "SRID": str(SRID) if SRID else None,

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -40,12 +40,12 @@ def leaflet_js(plugins=None):
     plugin_names = _get_plugin_names(plugins)
     with_forms = PLUGIN_FORMS in plugin_names or PLUGIN_ALL in plugin_names
     FORCE_IMAGE_PATH = app_settings.get('FORCE_IMAGE_PATH')
-    try:
+    if hasattr(settings,'TEMPLATE_DEBUG')
         debug = settings.TEMPLATE_DEBUG
-    except AttributeError:
-        try:
+    else:
+        if settings.TEMPLATES[0]['OPTIONS'].haskey('debug'):
             debug = settings.TEMPLATES[0]['OPTIONS']['debug']
-        except KeyError:
+        else:
             debug = False
     return {
         "DEBUG": debug,

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -40,7 +40,7 @@ def leaflet_js(plugins=None):
     plugin_names = _get_plugin_names(plugins)
     with_forms = PLUGIN_FORMS in plugin_names or PLUGIN_ALL in plugin_names
     FORCE_IMAGE_PATH = app_settings.get('FORCE_IMAGE_PATH')
-    if hasattr(settings,'TEMPLATE_DEBUG')
+    if hasattr(settings,'TEMPLATE_DEBUG'):
         debug = settings.TEMPLATE_DEBUG
     else:
         if settings.TEMPLATES[0]['OPTIONS'].haskey('debug'):

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -43,7 +43,7 @@ def leaflet_js(plugins=None):
     if hasattr(settings,'TEMPLATE_DEBUG'):
         debug = settings.TEMPLATE_DEBUG
     else:
-        if settings.TEMPLATES[0]['OPTIONS'].haskey('debug'):
+        if 'debug' in settings.TEMPLATES[0]['OPTIONS']:
             debug = settings.TEMPLATES[0]['OPTIONS']['debug']
         else:
             debug = False


### PR DESCRIPTION
In newer version of django, ```debug``` option is written in the ```OPTIONS``` of ```TEMPLATES``` instead.