### PR TITLE
[feature] add map to admin's change list (WIP - DO NOT MERGE)

### DIFF
--- a/leaflet/admin.py
+++ b/leaflet/admin.py
@@ -24,6 +24,7 @@ class LeafletGeoAdmin(ModelAdmin):
     map_width = '100%'
     map_height = '400px'
     display_raw = False
+    list_geom_field = None
 
     def formfield_for_dbfield(self, db_field, **kwargs):
         """
@@ -55,3 +56,6 @@ class LeafletGeoAdmin(ModelAdmin):
             map_height = self.map_height
             display_raw = self.display_raw
         return LeafletMap
+
+
+    change_list_template = 'leaflet/admin/change_list_geo.html'

--- a/leaflet/templates/leaflet/admin/change_list_geo.html
+++ b/leaflet/templates/leaflet/admin/change_list_geo.html
@@ -1,0 +1,99 @@
+{% extends 'admin/change_list.html' %}
+{% load leaflet_tags %}
+{% load admin_list_leaflet %}
+
+
+{% block stylesheets %}
+    {{ block.super }}
+    {% include 'leaflet/css.html' %}
+
+    <style>
+    .leaflet-container-default{
+    		min-width: 300px;
+    }
+    </style>
+
+{% endblock %}
+
+{% block javascripts %}
+    {{ block.super }}
+    {% include 'leaflet/js.html' %}
+{% endblock %}
+
+
+{% block result_list %}
+{% if cl.model_admin.list_geom_field %}
+
+{% leaflet_map "map" %}
+
+<script type="text/javascript">
+
+(function($) {
+
+	$('#map').addClass('grp-module');
+
+	// GeoJSON object 
+    var geojsonFeatures = {
+    	"type": "FeatureCollection",
+	    "features": [
+{% for result in cl.result_list %}
+		{
+	        	"type": "Feature",
+	        	"geometry": {{result|geom_field:cl.model_admin.list_geom_field|safe}},
+	        	"properties": {"pk": "{{result.pk}}",}
+	    }
+	    {% if not forloop.last %},{% endif %}
+{% endfor %}
+	    ]
+	}
+
+
+	window.addEventListener('map:init', function (e) {
+
+        var target_map = e.detail.map;
+
+        
+		// 1. We create and add the layer to the map
+		var featuresLayer = L.geoJson(geojsonFeatures, {
+    		onEachFeature: onEachFeature
+		});
+		featuresLayer.addTo(target_map);
+		target_map.fitBounds(featuresLayer.getBounds());
+
+		// 2. We hook into _selection_actions checkboxes to provide selection features
+		$('input[name="_selected_action"]').click(function(){
+        	var id = $(this).val();
+        	var checkbox = $('input[name="_selected_action"][value="'+id+'"]');
+        	var checked = $(checkbox).is(':checked');
+        	featuresLayer.eachLayer(function (layer) {  
+			  if(layer.feature.properties.pk == id) { 
+			  	if(!checked){
+			    	layer.setStyle({fillColor :'blue'}) 
+			  	}
+			  	else{
+			    	layer.setStyle({fillColor :'yellow'}) 
+			  	}
+			  }
+			});
+        });        
+    }, false);
+
+	// This functions add click and doubleclick handlers to the layer
+    function onEachFeature(feature, layer) {
+        	layer.on('click',function(){
+        		var checkbox = $('input[name="_selected_action"][value="'+this.feature.properties.pk+'"]');
+        		checkbox.click();
+        	});
+        	layer.on('dblclick',function(){
+        		window.location = "{% url 'admin:index' %}{{cl.opts.app_label}}/{{cl.opts.model_name}}/"+this.feature.properties.pk+'/';
+        	});
+		}
+
+})(grp.jQuery);
+
+</script>
+
+
+{% endif %}
+{{block.super}}
+{% endblock %}

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -110,6 +110,10 @@ def leaflet_json_config():
 
     return json.dumps(settings_as_json)
 
+@register.filter
+def geom_field(instance, field_name):
+    return getattr(instance, field_name).json
+
 
 def _get_plugin_names(plugin_names_from_tag_parameter):
     """


### PR DESCRIPTION
Hi,

This PR allows to display a map at top of admin's change list of LeafletGeoAdmins.

It's a quick draft and I'm new to Django, so it's **not ready for merge** and needs review.

Please let me know what you think.

![geoadmin](https://cloud.githubusercontent.com/assets/1894106/10968671/ae088882-83ba-11e5-8e14-d5b112eef7da.png)



**Features**

- single click : user can select entries both on the map and on the list (synced)
- double click : opens the entry's change page.

**How it works**

It works by setting LeafletGeoAdmin's `change_list_template` to a custom template which features a map before the list.
The map knows which field to use to display the features thanks to a new `list_geom_field` parameter on LeafletGeoAdmin. By default, it's set to None, in which case no map is displayed.

**How to use**
```
class MyAdmin(LeafletGeoAdmin):
    ...
    list_geom_field = 'mygeomfieldname'
    ...
```

**To do**

- Cleanup the selection hack (so that it works with select all for instance)
- Allow to completely replace the change list
- Support of labels, popups, etc.
- Customise click events
- One day : display inlines as a map too
- One day : allow to edit in place