### PR TITLE
Make sure we do not parse bad values

### DIFF
--- a/leaflet/forms/widgets.py
+++ b/leaflet/forms/widgets.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django import forms
+from django.core import validators
 from django.template.defaultfilters import slugify
 try:
     from django.contrib.gis.forms.widgets import BaseGeometryWidget
@@ -36,6 +37,8 @@ class LeafletWidget(BaseGeometryWidget):
 
     def render(self, name, value, attrs=None):
         assert self.map_srid == 4326, 'Leaflet vectors should be decimal degrees.'
+
+        value = None if value in validators.EMPTY_VALUES else value
 
         # Retrieve params from Field init (if any)
         self.geom_type = self.attrs.get('geom_type', self.geom_type)

--- a/leaflet/tests/tests.py
+++ b/leaflet/tests/tests.py
@@ -89,6 +89,11 @@ class LeafletWidgetRenderingTest(SimpleTestCase):
         self.assertIn('leaflet/leaflet.css', media_css)
         self.assertIn('leaflet/draw/leaflet.draw.css', media_css)
 
+    def test_widget_geometry_is_empty_string(self):
+        widget = LeafletWidget()
+        widget.render('geom', '', {'id': 'geom'})
+        self.assertTrue(True, 'We should\'t accept blank geometry in value.')
+
 
 class LeafletFieldsWidgetsTest(SimpleTestCase):
     def test_default_widget(self):


### PR DESCRIPTION
Django does not garantee the behavior of the value and thus it should be treated defensively in the render part of the widget to prevent unnecessary exceptions.