### PR TITLE
utf-8 fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
+
 import os
 from setuptools import setup, find_packages
 import sys
 
 here = os.path.abspath(os.path.dirname(__file__))
+import codecs
 
 requires = ['Django']
 if sys.version_info < (2, 7):
@@ -16,9 +18,12 @@ setup(
         url='https://github.com/makinacorpus/django-leaflet',
         download_url="http://pypi.python.org/pypi/django-leaflet/",
         description="Use Leaflet in your django projects",
-        long_description=open(
-            os.path.join(here, 'README.rst')).read() + '\n\n' +
-                         open(os.path.join(here, 'CHANGES')).read(),
+        long_description=codecs.open(
+            os.path.join(
+                here, 'README.rst'), 'r', 'utf-8').read() + '\n\n' +
+                         codecs.open(
+                             os.path.join(here, 'CHANGES'), 
+                             'r', 'utf-8').read(),
         license='LPGL, see LICENSE file.',
         install_requires=requires,
         packages=find_packages(),


### PR DESCRIPTION
to fix 
```
Collecting django-leaflet==0.18.0 (from -r /requirements.txt (line 8))
  Using cached django-leaflet-0.18.0.zip
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-zg1ymiwx/django-leaflet/setup.py", line 20, in <module>
        os.path.join(here, 'README.rst')).read() + '\n\n' +
      File "/srv/projects/*/venv/lib/python3.4/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 15096: ordinal not in range(128)
```