### PR TITLE
Spatial extent overrides

### DIFF
--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -71,19 +71,23 @@ def leaflet_map(name, callback=None, fitextent=True, creatediv=True,
     :param settings_overrides:
     :return:
     """
-    extent = None
-    if SPATIAL_EXTENT is not None:
-        # Leaflet uses [lat, lng]
-        xmin, ymin, xmax, ymax = SPATIAL_EXTENT
-        extent = (ymin, xmin, ymax, xmax)
 
     if settings_overrides == '':
         settings_overrides = {}
     app_settings.update(**settings_overrides)
 
+    def computeSpatialExtent(app_settings):
+        if app_settings['SPATIAL_EXTENT'] is not None:
+            # Leaflet uses [lat, lng]
+            xmin, ymin, xmax, ymax = app_settings['SPATIAL_EXTENT']
+            extent = (ymin, xmin, ymax, xmax)
+            return [extent[:2], extent[2:4]]
+        else:
+            return None
+
     djoptions = dict(
         srid=SRID,
-        extent=[extent[:2], extent[2:4]],
+        extent=computeSpatialExtent(app_settings),
         fitextent=fitextent,
         center=app_settings['DEFAULT_CENTER'],
         zoom=app_settings['DEFAULT_ZOOM'],
@@ -97,7 +101,7 @@ def leaflet_map(name, callback=None, fitextent=True, creatediv=True,
         resetview=app_settings.get('RESET_VIEW'),
         tilesextent=list(app_settings.get('TILES_EXTENT', []))
     )
-
+    print(djoptions)
     return {
         # templatetag options
         'name': name,

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -74,34 +74,38 @@ def leaflet_map(name, callback=None, fitextent=True, creatediv=True,
 
     if settings_overrides == '':
         settings_overrides = {}
-    app_settings.update(**settings_overrides)
+
+    instance_app_settings = app_settings.copy() #Allow not overidding global settings_overrides
+    instance_app_settings.update(**settings_overrides)
 
     def computeSpatialExtent(app_settings):
-        if app_settings['SPATIAL_EXTENT'] is not None:
+        if instance_app_settings['SPATIAL_EXTENT'] is not None:
             # Leaflet uses [lat, lng]
-            xmin, ymin, xmax, ymax = app_settings['SPATIAL_EXTENT']
+            xmin, ymin, xmax, ymax = instance_app_settings['SPATIAL_EXTENT']
             extent = (ymin, xmin, ymax, xmax)
             return [extent[:2], extent[2:4]]
         else:
             return None
 
+    extent = computeSpatialExtent(app_settings)
+
     djoptions = dict(
         srid=SRID,
-        extent=computeSpatialExtent(app_settings),
+        extent=extent,
         fitextent=fitextent,
-        center=app_settings['DEFAULT_CENTER'],
-        zoom=app_settings['DEFAULT_ZOOM'],
-        minzoom=app_settings['MIN_ZOOM'],
-        maxzoom=app_settings['MAX_ZOOM'],
-        layers=[(force_text(label), url, attrs) for (label, url, attrs) in app_settings.get('TILES')],
-        overlays=[(force_text(label), url, attrs) for (label, url, attrs) in app_settings.get('OVERLAYS')],
-        attributionprefix=force_text(app_settings.get('ATTRIBUTION_PREFIX'), strings_only=True),
-        scale=app_settings.get('SCALE'),
-        minimap=app_settings.get('MINIMAP'),
-        resetview=app_settings.get('RESET_VIEW'),
-        tilesextent=list(app_settings.get('TILES_EXTENT', []))
+        center=instance_app_settings['DEFAULT_CENTER'],
+        zoom=instance_app_settings['DEFAULT_ZOOM'],
+        minzoom=instance_app_settings['MIN_ZOOM'],
+        maxzoom=instance_app_settings['MAX_ZOOM'],
+        layers=[(force_text(label), url, attrs) for (label, url, attrs) in instance_app_settings.get('TILES')],
+        overlays=[(force_text(label), url, attrs) for (label, url, attrs) in instance_app_settings.get('OVERLAYS')],
+        attributionprefix=force_text(instance_app_settings.get('ATTRIBUTION_PREFIX'), strings_only=True),
+        scale=instance_app_settings.get('SCALE'),
+        minimap=instance_app_settings.get('MINIMAP'),
+        resetview=instance_app_settings.get('RESET_VIEW'),
+        tilesextent=list(instance_app_settings.get('TILES_EXTENT', []))
     )
-    
+
     return {
         # templatetag options
         'name': name,
@@ -111,7 +115,7 @@ def leaflet_map(name, callback=None, fitextent=True, creatediv=True,
         # initialization options
         'djoptions': json.dumps(djoptions, cls=JSONLazyTranslationEncoder),
         # settings
-        'NO_GLOBALS': app_settings.get('NO_GLOBALS'),
+        'NO_GLOBALS': instance_app_settings.get('NO_GLOBALS'),
     }
 
 

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -78,7 +78,7 @@ def leaflet_map(name, callback=None, fitextent=True, creatediv=True,
     instance_app_settings = app_settings.copy()  # Allow not overidding global settings_overrides
     instance_app_settings.update(**settings_overrides)
 
-    def computeSpatialExtent(app_settings):
+    def computeSpatialExtent():
         if instance_app_settings['SPATIAL_EXTENT'] is not None:
             # Leaflet uses [lat, lng]
             xmin, ymin, xmax, ymax = instance_app_settings['SPATIAL_EXTENT']
@@ -87,7 +87,7 @@ def leaflet_map(name, callback=None, fitextent=True, creatediv=True,
         else:
             return None
 
-    extent = computeSpatialExtent(app_settings)
+    extent = computeSpatialExtent()
 
     djoptions = dict(
         srid=SRID,

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -75,7 +75,7 @@ def leaflet_map(name, callback=None, fitextent=True, creatediv=True,
     if settings_overrides == '':
         settings_overrides = {}
 
-    instance_app_settings = app_settings.copy()  # Allow not overidding global settings_overrides
+    instance_app_settings = app_settings.copy()  # Allow not overidding global app_settings
     instance_app_settings.update(**settings_overrides)
 
     def computeSpatialExtent():

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -101,7 +101,7 @@ def leaflet_map(name, callback=None, fitextent=True, creatediv=True,
         resetview=app_settings.get('RESET_VIEW'),
         tilesextent=list(app_settings.get('TILES_EXTENT', []))
     )
-    print(djoptions)
+    
     return {
         # templatetag options
         'name': name,

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -78,16 +78,12 @@ def leaflet_map(name, callback=None, fitextent=True, creatediv=True,
     instance_app_settings = app_settings.copy()  # Allow not overidding global app_settings
     instance_app_settings.update(**settings_overrides)
 
-    def computeSpatialExtent():
-        if instance_app_settings['SPATIAL_EXTENT'] is not None:
-            # Leaflet uses [lat, lng]
-            xmin, ymin, xmax, ymax = instance_app_settings['SPATIAL_EXTENT']
-            extent = (ymin, xmin, ymax, xmax)
-            return [extent[:2], extent[2:4]]
-        else:
-            return None
-
-    extent = computeSpatialExtent()
+    extent = None
+    if instance_app_settings['SPATIAL_EXTENT'] is not None:
+        # Leaflet uses [lat, lng]
+        xmin, ymin, xmax, ymax = instance_app_settings['SPATIAL_EXTENT']
+        bbox = (ymin, xmin, ymax, xmax)
+        extent = [bbox[:2], bbox[2:4]]
 
     djoptions = dict(
         srid=SRID,

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -75,7 +75,7 @@ def leaflet_map(name, callback=None, fitextent=True, creatediv=True,
     if settings_overrides == '':
         settings_overrides = {}
 
-    instance_app_settings = app_settings.copy() #Allow not overidding global settings_overrides
+    instance_app_settings = app_settings.copy()  # Allow not overidding global settings_overrides
     instance_app_settings.update(**settings_overrides)
 
     def computeSpatialExtent(app_settings):

--- a/leaflet/tests/tests.py
+++ b/leaflet/tests/tests.py
@@ -189,6 +189,24 @@ class SettingsOverridesTest(SimpleTestCase):
         output = widget.render('geom', '', {'id': 'geom'})
         self.assertIn('"center": [8.0, 3.14]', output)
 
+    def test_spatial_extent_settings_overrides(self):
+        widget = LeafletWidget(attrs={
+            'settings_overrides': {
+                'SPATIAL_EXTENT': (
+                    3.812255859375,
+                    50.387507803003146,
+                    4.0869140625,
+                    50.523904629228625,
+                ),
+                'DEFAULT_ZOOM': None,
+                'DEFAULT_CENTER': None,
+            }
+        })
+        output = widget.render('geom', '', {'id': 'geom'})
+        self.assertIn('"extent": [[50.387507803003146, 3.812255859375], [50.523904629228625, 4.0869140625]]', output)
+        self.assertIn('"center": null', output)
+        self.assertIn('"zoom": null', output)
+
 
 class LeafletModelFormTest(SimpleTestCase):
 


### PR DESCRIPTION
Hello,

This pr allow to override spatial extent. Before, only the spatial extent specified in the django settings was used.

Sample use case that this pr allow

```
        self.fields['geometry'].widget = LeafletWidget(attrs={
            'settings_overrides': {
                'SPATIAL_EXTENT': (
                    self.spatial_extent[0],
                    self.spatial_extent[1],
                    self.spatial_extent[2],
                    self.spatial_extent[3]
                ),
                'DEFAULT_ZOOM' : None, #Zoom need to be null for fitextent
                'DEFAULT_CENTER' : None, #Center need to be null for fitextent
            }
        })
```

**Update**

This pr change the way app_settings_overrides affect the global variable app_settings (from leaflet). Before if the above code was used, the global app_settings variable was updated with overrided values.

So every map displayed after was affected by the overrided values. I think this is a bug (maybe it was on purpose?)

see : https://github.com/makinacorpus/django-leaflet/blob/master/leaflet/templatetags/leaflet_tags.py#L82
