### PR TITLE
Fix for incorrect debug detection in templatetags.leflet_js.

### DIFF
--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -40,11 +40,12 @@ def leaflet_js(plugins=None):
     plugin_names = _get_plugin_names(plugins)
     with_forms = PLUGIN_FORMS in plugin_names or PLUGIN_ALL in plugin_names
     FORCE_IMAGE_PATH = app_settings.get('FORCE_IMAGE_PATH')
+    template_options = settings.TEMPLATES and len(settings.TEMPLATES) and settings.TEMPLATES[0].get('OPTIONS', None)
 
-    if hasattr(settings, 'TEMPLATE_DEBUG'):
+    if template_options and 'debug' in template_options:
+        debug = template_options['debug']
+    elif hasattr(settings, 'TEMPLATE_DEBUG'):
         debug = settings.TEMPLATE_DEBUG
-    elif 'debug' in settings.TEMPLATES[0]['OPTIONS']:
-        debug = settings.TEMPLATES[0]['OPTIONS']['debug']
     else:
         debug = False
 

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -41,8 +41,8 @@ def leaflet_js(plugins=None):
     with_forms = PLUGIN_FORMS in plugin_names or PLUGIN_ALL in plugin_names
     FORCE_IMAGE_PATH = app_settings.get('FORCE_IMAGE_PATH')
     template_options = settings.TEMPLATES \
-                       and len(settings.TEMPLATES) \
-                       and settings.TEMPLATES[0].get('OPTIONS', None)
+        and len(settings.TEMPLATES) \
+        and settings.TEMPLATES[0].get('OPTIONS', None)
 
     if template_options and 'debug' in template_options:
         debug = template_options['debug']

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -40,7 +40,9 @@ def leaflet_js(plugins=None):
     plugin_names = _get_plugin_names(plugins)
     with_forms = PLUGIN_FORMS in plugin_names or PLUGIN_ALL in plugin_names
     FORCE_IMAGE_PATH = app_settings.get('FORCE_IMAGE_PATH')
-    template_options = settings.TEMPLATES and len(settings.TEMPLATES) and settings.TEMPLATES[0].get('OPTIONS', None)
+    template_options = settings.TEMPLATES \
+                       and len(settings.TEMPLATES) \
+                       and settings.TEMPLATES[0].get('OPTIONS', None)
 
     if template_options and 'debug' in template_options:
         debug = template_options['debug']


### PR DESCRIPTION
Currently in Django 1.9 there is still a `TEMPLATE_DEBUG=False` in `django.conf.global_settings` which causes the current debug detection procedure to get incorrect results if your settings comply with the new Django `TEMPLATE` settings.

This solution works in 1.9 and is backwards compatible with all previous versions.