### PR TITLE
Unable to collectstatic with non-default STATICFILES_STORAGE

### DIFF
--- a/leaflet/tests/tests.py
+++ b/leaflet/tests/tests.py
@@ -30,27 +30,28 @@ class AppLoadingTest(SimpleTestCase):
         Non-default STATICFILES_STORAGE (ex. django.contrib.staticfiles.storage.ManifestStaticFilesStorage)
         might raise ValueError when file could not be found by this storage and DEBUG is set to False.
 
-        Ensure that _normalize_plugins_config calls `static` lazily, in order to let `collectstatic` command to run.
+        Ensure that _normalize_plugins_config calls `static` lazily, in order to let the `collectstatic` command to run.
 
         """
 
         try:
-            with self.settings(STATICFILES_STORAGE='leaflet.tests.tests.DummyStaticFilesStorage', STATIC_ROOT="/", DEBUG=False):
+            with self.settings(STATICFILES_STORAGE='leaflet.tests.tests.DummyStaticFilesStorage',
+                               STATIC_ROOT="/", DEBUG=False):
                 staticfiles_storage._setup()  # reset already initialized (and memoized) default STATICFILES_STORAGE
 
-                try:
+                with self.assertRaises(ValueError):
+                    # Ensure that our DummyStaticFilesStorage is unable to process `static` calls right now
                     static("a")
-                    self.fail("static must raise an exception")
-                except ValueError:
-                    pass
 
                 PLUGINS.update({
                     'a': {'css': 'a'},
                 })
 
                 PLUGINS.pop('__is_normalized__')
+                # This would raise if `static` calls are not lazy
                 _normalize_plugins_config()
         finally:
+            # Reset the STATICFILES_STORAGE to a default one
             staticfiles_storage._setup()
             _normalize_plugins_config()
 

--- a/leaflet/tests/tests.py
+++ b/leaflet/tests/tests.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import json
 
 import django
-from django.contrib.staticfiles.storage import StaticFilesStorage
+from django.contrib.staticfiles.storage import StaticFilesStorage, staticfiles_storage
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.test import SimpleTestCase
 from django.contrib.gis.db import models as gismodels
@@ -34,20 +34,24 @@ class AppLoadingTest(SimpleTestCase):
 
         """
 
-        with self.settings(STATICFILES_STORAGE='leaflet.tests.tests.DummyStaticFilesStorage', STATIC_ROOT="/", DEBUG=False):
-            # staticfiles_storage._setup()  # reset already initialized default STATICFILES_STORAGE
+        try:
+            with self.settings(STATICFILES_STORAGE='leaflet.tests.tests.DummyStaticFilesStorage', STATIC_ROOT="/", DEBUG=False):
+                staticfiles_storage._setup()  # reset already initialized (and memoized) default STATICFILES_STORAGE
 
-            try:
-                static("a")
-                self.fail("static must raise an exception")
-            except ValueError:
-                pass
+                try:
+                    static("a")
+                    self.fail("static must raise an exception")
+                except ValueError:
+                    pass
 
-            PLUGINS.update({
-                'a': {'css': 'a'},
-            })
+                PLUGINS.update({
+                    'a': {'css': 'a'},
+                })
 
-            PLUGINS.pop('__is_normalized__')
+                PLUGINS.pop('__is_normalized__')
+                _normalize_plugins_config()
+        finally:
+            staticfiles_storage._setup()
             _normalize_plugins_config()
 
 


### PR DESCRIPTION
When STATICFILES_STORAGE is set to some complicated storage (like `django.contrib.staticfiles.storage.ManifestStaticFilesStorage`) and DEBUG is set to off, `static` templatetag might raise a ValueError complaining about non-existing file (see the attached traceback).

As a result, it is impossible for collectstatic to actually create these non-existing files, unless it is run with DEBUG=True for the first time.

This is caused by filling `PLUGINS` during app import.

The clear solution (as for me) is to replace PLUGINS dict with a class which lazily calls `static` when required. I might work on it, if you think this would be an appropriate solution.

Added a failing testcase for this.

Here is a traceback of collectstatic call (django 1.9):

```
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/.virtualenvs/vvv/lib/python3.4/site-packages/django/core/management/__init__.py", line 353, in execute_from_command_line
    utility.execute()
  File "/home/.virtualenvs/vvv/lib/python3.4/site-packages/django/core/management/__init__.py", line 327, in execute
    django.setup()
  File "/home/.virtualenvs/vvv/lib/python3.4/site-packages/django/__init__.py", line 18, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/home/.virtualenvs/vvv/lib/python3.4/site-packages/django/apps/registry.py", line 85, in populate
    app_config = AppConfig.create(entry)
  File "/home/.virtualenvs/vvv/lib/python3.4/site-packages/django/apps/config.py", line 90, in create
    module = import_module(entry)
  File "/home/.virtualenvs/vvv/lib/python3.4/importlib/__init__.py", line 109, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 2254, in _gcd_import
  File "<frozen importlib._bootstrap>", line 2237, in _find_and_load
  File "<frozen importlib._bootstrap>", line 2226, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1200, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1129, in _exec
  File "<frozen importlib._bootstrap>", line 1471, in exec_module
  File "<frozen importlib._bootstrap>", line 321, in _call_with_frames_removed
  File "/home/.virtualenvs/vvv/lib/python3.4/site-packages/leaflet/__init__.py", line 204, in <module>
    _normalize_plugins_config()
  File "/home/.virtualenvs/vvv/lib/python3.4/site-packages/leaflet/__init__.py", line 191, in _normalize_plugins_config
    urls[i] = static(url)
  File "/home/.virtualenvs/vvv/lib/python3.4/site-packages/django/contrib/staticfiles/templatetags/staticfiles.py", line 9, in static
    return staticfiles_storage.url(path)
  File "/home/.virtualenvs/vvv/lib/python3.4/site-packages/django/contrib/staticfiles/storage.py", line 131, in url
    hashed_name = self.stored_name(clean_name)
  File "/home/.virtualenvs/vvv/lib/python3.4/site-packages/django/contrib/staticfiles/storage.py", line 280, in stored_name
    cache_name = self.clean_name(self.hashed_name(name))
  File "/home/.virtualenvs/vvv/lib/python3.4/site-packages/django/contrib/staticfiles/storage.py", line 94, in hashed_name
    (clean_name, self))
ValueError: The file 'leaflet/draw/leaflet.draw.css' could not be found with <django.contrib.staticfiles.storage.ManifestStaticFilesStorage object at 0x7f1fc2dd80b8>.
```
