### PR TITLE
Fix #165 (zoom level is not max)

### DIFF
--- a/leaflet/static/leaflet/leaflet.forms.js
+++ b/leaflet/static/leaflet/leaflet.forms.js
@@ -177,12 +177,7 @@ L.GeometryField = L.Class.extend({
         // Change view extent
         if (this.drawnItems.getLayers().length > 0) {
             var bounds = this.drawnItems.getBounds();
-            // In case of points, fitBounds() fails.
-            // https://github.com/makinacorpus/django-leaflet/issues/90
-            if (!bounds._southWest.equals(bounds._northEast))
-                this._map.fitBounds(bounds);
-            else
-                this._map.setView(bounds._northEast, this.default_zoom);
+            this._map.fitBounds(this.drawnItems.getBounds());
         }
         // Else keep view extent set by django-leaflet template tag
     },


### PR DESCRIPTION
This PR reverts PR #95, which was implemented as a workaround for issue #90. It seems that Leaflet has been fixed in the meantime so that the hangup encountered in issue #90 no longer occurs. Therefore the workaround (#95) is no longer needed and this then resolves the side-effect of #95 (filed as issue #165) wherein if the geometry field to be displayed is a point, the zoom level is not the maximum (because `fitBounds()` was bypassed).
