### PR TITLE
Use SpatiaLite library path from environment variable for running tests

### DIFF
--- a/quicktest.py
+++ b/quicktest.py
@@ -66,6 +66,15 @@ class QuickDjangoTest(object):
             'INSTALLED_APPS': self.INSTALLED_APPS + self.apps,
             'STATIC_URL': '/static/',
         }
+        if 'SPATIALITE_LIBRARY_PATH' in os.environ:
+            # If you get SpatiaLite-related errors, refer to this document
+            # to find out the proper SPATIALITE_LIBRARY_PATH value
+            # for your platform.
+            # https://docs.djangoproject.com/en/dev/ref/contrib/gis/install/spatialite/
+            #
+            # Example for macOS (with spatialite-tools installed using brew):
+            # $ export SPATIALITE_LIBRARY_PATH='/usr/local/lib/mod_spatialite.dylib'
+            conf['SPATIALITE_LIBRARY_PATH'] = os.getenv('SPATIALITE_LIBRARY_PATH')
         if django.VERSION >= (1, 8, 0):
             conf['TEMPLATES'] = self.TEMPLATES,
         settings.configure(**conf)


### PR DESCRIPTION
Running tests on macOS now causes the error:
```
django.core.exceptions.ImproperlyConfigured: Unable to load the SpatiaLite library extension "/usr/local/lib/libspatialite.dylib" because: dlsym(0x7fbadca059c0, sqlite3_spatialite_init): symbol not found
```

With this patch one can run tests this way (without modifying the `quicktest.py` file itself):
```
export SPATIALITE_LIBRARY_PATH='/usr/local/lib/mod_spatialite.dylib'
python ./quicktest.py leaflet --db=sqlite
```