### PR TITLE
Add missing recursive-include for svg files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ recursive-include leaflet/templates *.html *.js
 recursive-include leaflet/static *.js
 recursive-include leaflet/static *.css
 recursive-include leaflet/static *.png
+recursive-include leaflet/static *.svg


### PR DESCRIPTION
leaflet.draw uses a svg file, so we need to include them in the packaging
leaflet/static/leaflet/draw/images/spritesheet.svg