### PR TITLE
[JS] Allow storing global leaflet map instances

### DIFF
--- a/leaflet/templates/leaflet/_leaflet_map.html
+++ b/leaflet/templates/leaflet/_leaflet_map.html
@@ -7,8 +7,11 @@
     function loadmap() {
         var djoptions = {% autoescape off %}{{ djoptions }}{% endautoescape %},
             options = {djoptions: djoptions, initfunc: loadmap,
-                       globals: {{ NO_GLOBALS|yesno:"false,true"}}, callback: {{ callback|default:"null" }}};
-        L.Map.djangoMap('{{ name }}', options);
+                       globals: {{ NO_GLOBALS|yesno:"false,true"}}, callback: {{ callback|default:"null" }}},
+            map = L.Map.djangoMap('{{ name }}', options);
+        {% if not NO_GLOBALS %}
+        window['leafletmap' + '{{ name }}'] = map;
+        {% endif %}
     }
     var loadevents = {% autoescape off %}{{ loadevents }}{% endautoescape %};
     if (loadevents.length === 0) loadmap();


### PR DESCRIPTION
This patch allows to store global references to leaflet map instances created in `loadmap()` in order to enable more complex customisations that require direct access to the leaflet map instances.

I couldn't find a way to do this so I've done this in my project, but I would prefer to avoid overriding the entire `_leaflet_map.html` template and having this small change included upstream instead.

Looking forward to hear feedback.
Best regards.