### PR TITLE
Fix FORCE_IMAGE_PATH option

### DIFF
--- a/leaflet/templates/leaflet/js.html
+++ b/leaflet/templates/leaflet/js.html
@@ -21,6 +21,6 @@
     L.Control.ResetView.TITLE = "{% trans "Reset view" %}";
     L.Control.ResetView.ICON = "url({% static "leaflet/images/reset-view.png" %})";
     {% if FORCE_IMAGE_PATH %}
-    L.Icon.Default.imagePath = "{% static "leaflet/images" %}";
+    L.Icon.Default.imagePath = "{% static "leaflet/images" %}/";
     {% endif %}
 </script>


### PR DESCRIPTION
It produced URLs that didn't have a slash between path and leafname, ending up with URLs like `/static/leafletmarker-icon.png`.