### PR TITLE
Fix typo and travis build (Locale ES)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ install:
  - sudo apt-get install -y libproj-dev libgeos-dev
 
  - if [[ $DATABASE == sqlite ]]; then sudo apt-get install -y libspatialite-dev; fi
- - if [[ $DATABASE == sqlite ] && [ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install pysqlite==2.8.2; fi
+ - if [ $DATABASE == sqlite ] && [ $TRAVIS_PYTHON_VERSION == 2.7 ]; then pip install pysqlite==2.8.2; fi
  - if [[ $DATABASE == postgres ]]; then pip install psycopg2; fi
 
    # This is a dependency of our Django test script

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ install:
  - dpkg -l
 
 before_script:
- - flake8 --ignore=E501 leaflet
+ - flake8 --ignore=E501,W504 leaflet
  - if [[ $DATABASE == postgres ]]; then psql -c 'create database test_db;' -U postgres; fi
  - if [[ $DATABASE == postgres ]]; then psql -c 'CREATE EXTENSION postgis;' -U postgres -d test_db; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ install:
  - sudo apt-get install -y libproj-dev libgeos-dev
 
  - if [[ $DATABASE == sqlite ]]; then sudo apt-get install -y libspatialite-dev; fi
- - if [[ $DATABASE == sqlite ]]; then pip install pysqlite==2.8.2; fi
+ - if [[ $DATABASE == sqlite ] && [ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install pysqlite==2.8.2; fi
  - if [[ $DATABASE == postgres ]]; then pip install psycopg2; fi
 
    # This is a dependency of our Django test script

--- a/leaflet/locale/es/LC_MESSAGES/django.po
+++ b/leaflet/locale/es/LC_MESSAGES/django.po
@@ -28,14 +28,14 @@ msgstr "Fondo"
 
 msgid "Spatial extent should be a tuple (minx, miny, maxx, maxy)"
 msgstr ""
-"La extension (spatial extent) deve ser una tupla de tipo (minx, miny, maxx, "
+"La extensión (spatial extent) debe ser una tupla de tipo (minx, miny, maxx, "
 "maxy)"
 
 msgid "Draw a polyline"
-msgstr "Dibujar una linea"
+msgstr "Dibujar una polilínea"
 
 msgid "Draw a polygon"
-msgstr "Dibujar un poligono"
+msgstr "Dibujar un polígono"
 
 msgid "Draw a rectangle"
 msgstr "Dibujar un rectángulo"
@@ -53,29 +53,29 @@ msgid "Click map to place marker."
 msgstr "Haz click sobre el mapa para dibujar un marcador."
 
 msgid "Click to start drawing shape."
-msgstr "Haz click para comenzar a dibujar la geometría."
+msgstr "Haz click para comenzar a dibujar una figura"
 
 msgid "Click to continue drawing shape."
-msgstr "Haz click para continuar dibujando la geometría."
+msgstr "Haz click para continuar dibujando la figura"
 
 msgid "Click first point to close this shape."
-msgstr "Haz click en el primer punto para cerrar la geometría."
+msgstr "Haz click en el primer punto para cerrar esta figura."
 
 msgid "<strong>Error:</strong> shape edges cannot cross!"
 msgstr ""
-"<strong>Error:</strong> ¡los segmentos no se pueden cruzarles!"
+"<strong>Error:</strong> ¡los segmentos no se pueden cruzar!"
 
 msgid "Click to start drawing line."
-msgstr "Haz click para comenzar a dibujar una linea."
+msgstr "Haz click para comenzar a dibujar una línea."
 
 msgid "Click to continue drawing line."
-msgstr "Haz click para continuar dibujando la linea."
+msgstr "Haz click para continuar dibujando la línea."
 
 msgid "Click last point to finish line."
-msgstr "Haz click sobre el ultimo punto para terminar la linea."
+msgstr "Haz click sobre el último punto para terminar la línea."
 
 msgid "Click and drag to draw rectangle."
-msgstr "Haz click y arrastra para dibujar un rectangulo."
+msgstr "Haz click y arrastra para dibujar un rectángulo."
 
 msgid "Release mouse to finish drawing."
 msgstr "libera el raton para terminar de dibujar."
@@ -87,7 +87,7 @@ msgid "Save"
 msgstr "Guardar"
 
 msgid "Cancel editing, discards all changes."
-msgstr "Cancelar la edición, anulará todos los cambios."
+msgstr "Cancelar la edición y descartar todos los cambios."
 
 msgid "Cancel"
 msgstr "Cancelar"
@@ -99,25 +99,25 @@ msgid "Delete last point drawn"
 msgstr "Eliminar el último punto dibujado"
 
 msgid "Delete last point"
-msgstr "Suprimir el último punto"
+msgstr "Eliminar el último punto"
 
 msgid "Edit layers"
 msgstr "Editar capas"
 
 msgid "No layers to edit."
-msgstr "Ninguna capa a editar."
+msgstr "No existen capas a editar."
 
 msgid "No layers to delete."
-msgstr "Ninguna capa a suprimir."
+msgstr "No existen capas a eliminar."
 
 msgid "Delete layers"
-msgstr "Suprimir la capa."
+msgstr "Eliminar capas."
 
 msgid "Drag handles, or marker to edit feature."
-msgstr "Desplazar las marcas o puntos para editar la geometría."
+msgstr "Desplazar las marcas o puntos para editar la figura."
 
 msgid "Click cancel to undo changes."
 msgstr "Haz click en cancelar para deshacer los cambios."
 
 msgid "Click on a feature to remove"
-msgstr "Haz click en una geometría para suprimirla"
+msgstr "Haz click en una figura para eliminarla"


### PR DESCRIPTION
Fixed some words and added missing accents. Also fixed failed travis build by adding ignore W504 error on flake8 command args.

Automated build output without changes:

leaflet/admin.py:35:40: W504 line break after binary operator
The command "flake8 --ignore=E501 leaflet" failed and exited with 1 during .