### PR TITLE
use a custom widget if one is specified

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ CHANGELOG
 -------------------
 
 - #225 changes in staticfiles for django 1.11.14
+- #248 Allow use of a custom widget in the Admin. (fixes #151)
 
 0.24.0 (2018-06-07)
 -------------------

--- a/leaflet/admin.py
+++ b/leaflet/admin.py
@@ -38,33 +38,22 @@ class LeafletGeoAdminMixin(object):
         if is_editable:
             kwargs.pop('request', None)  # unsupported for form field
             # Setting the widget with the newly defined widget.
-            if 'widget' in kwargs:
-                w = kwargs['widget']
+            widget = self.widget
+            if 'widget' in kwargs and issubclass(kwargs['widget'], LeafletWidget):
                 # If the widget is already a LeafletWidget of some kind
                 # Then use it rather than a blank one.
-                if issubclass(w, LeafletWidget):
-                    class LeafletMap(w):
-                        template_name = self.map_template
-                        include_media = True
-                        geom_type = db_field.geom_type
-                        modifiable = self.modifiable
-                        map_width = self.map_width
-                        map_height = self.map_height
-                        display_raw = self.display_raw
-                        settings_overrides = self.settings_overrides
-                    kwargs['widget'] = LeafletMap
-                    return db_field.formfield(**kwargs)
+                widget = kwargs['widget']
 
-            kwargs['widget'] = self._get_map_widget(db_field)
+            kwargs['widget'] = self._get_map_widget(db_field, widget)
             return db_field.formfield(**kwargs)
         else:
             return super(LeafletGeoAdminMixin, self).formfield_for_dbfield(db_field, **kwargs)
 
-    def _get_map_widget(self, db_field):
+    def _get_map_widget(self, db_field, widget):
         """
         Overriden LeafletWidget with LeafletGeoAdmin params.
         """
-        class LeafletMap(self.widget):
+        class LeafletMap(widget):
             template_name = self.map_template
             include_media = True
             geom_type = db_field.geom_type

--- a/leaflet/admin.py
+++ b/leaflet/admin.py
@@ -38,6 +38,23 @@ class LeafletGeoAdminMixin(object):
         if is_editable:
             kwargs.pop('request', None)  # unsupported for form field
             # Setting the widget with the newly defined widget.
+            if 'widget' in kwargs:
+                w = kwargs['widget']
+                # If the widget is already a LeafletWidget of some kind
+                # Then use it rather than a blank one.
+                if issubclass(w, LeafletWidget):
+                    class LeafletMap(w):
+                        template_name = self.map_template
+                        include_media = True
+                        geom_type = db_field.geom_type
+                        modifiable = self.modifiable
+                        map_width = self.map_width
+                        map_height = self.map_height
+                        display_raw = self.display_raw
+                        settings_overrides = self.settings_overrides
+                    kwargs['widget'] = LeafletMap
+                    return db_field.formfield(**kwargs)
+
             kwargs['widget'] = self._get_map_widget(db_field)
             return db_field.formfield(**kwargs)
         else:


### PR DESCRIPTION
Fixes (for me at least) #151 

Not sure what to do if an instance is passed as the widget rather than a class, and might want to check the other fields on LeafletMap and merge them with the widget if needed (Tho some of them can be overridden in other ways).

This at least lets me use a custom geometry_field_class, so I can disable the rectangle control.

