### PR TITLE
Add CSS class .django-leaflet-raw-textarea to raw textarea, default width 100%

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,8 @@ CHANGELOG
 -------------------
 
 - #225 changes in staticfiles for django 1.11.14
-- #247 Allow resizing of raw Geometry textbox input via CSS, improve label
+- #247 Allow resizing of raw Geometry textbox input via CSS, improve label, add docs
+- #108 Add examples to docs on adding overlays, customising maps in templates, admin and forms
 - #248 Allow use of a custom widget in the Admin. (fixes #151)
 
 0.24.0 (2018-06-07)

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ CHANGELOG
 -------------------
 
 - #225 changes in staticfiles for django 1.11.14
+- #247 Allow resizing of raw Geometry textbox input via CSS, improve label
 - #248 Allow use of a custom widget in the Admin. (fixes #151)
 
 0.24.0 (2018-06-07)

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -78,6 +78,11 @@ CSS is your friend:
             height: 800px;
         }
 
+        /* Resize the "display_raw" textbox */
+        .django-leaflet-raw-textarea {
+            width: 100%;
+        }
+
     </style>
 
 
@@ -147,7 +152,7 @@ list, as shown below.
 
 Note that this will also prevent any overlays defined in settings from being displayed.
 
-
+.. _overlays:
 Overlay layers
 ~~~~~~~~~~~~~~
 

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -156,8 +156,54 @@ To globally add an overlay layer, use the same syntax as tiles::
     'OVERLAYS': [('Cadastral', 'http://server/a/{z}/{x}/{y}.png', {'attribution': '&copy; IGN'})]
 
 Currently, overlay layers from settings are limited to tiles. For vectorial overlays, you
-will have to add them via JavaScript (see events).
+will have to add them via JavaScript (see also events).
 
+.. new section: worked example on including WMS overlays
+To add layers other than the tiles supported by the global config, e.g. WMS layers,
+insert a script block, get a reference to the map's ``layerscontrol``, and add any layer supported by Leaflet
+as overlays to that layerscontrol object.
+
+
+In a template:
+
+::
+
+    {% block content %}
+    {% leaflet_map "detailmap" callback="window.map_init" %}
+    {% endblock %}
+
+
+    {% block javascript %}
+    {{ block.super }}
+    <script type="text/javascript">
+    function map_init(map, options) {
+        {% include 'shared/overlays.html' %}
+    }
+    </script>
+    {% endblock %}
+
+In a snippet, here called ``shared/overlays.html``, the overlays are configured.
+Doing so in a snippet allows the same set of overlays to be re-used across other maps in your Django project.
+
+``shared/overlays.html``:
+
+::
+
+    var lc = map.layerscontrol;
+
+    // An example from the Atlas of Living Australia https://www.ala.org.au/
+    lc.addOverlay(L.tileLayer.wms('https://spatial-beta.ala.org.au/geoserver/ALA/wms',
+    {
+        layers: 'ALA:11385_species_richness',
+        format: 'image/png',
+        transparent: true,
+    }),
+    'Species Richness');
+
+    // add lc.addOverlay() layers as needed
+
+For an overview of available layer types and options, see the
+[Leaflet docs on tile layers](https://leafletjs.com/examples/wms/wms.html).
 
 Attribution prefix
 ~~~~~~~~~~~~~~~~~~

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -197,13 +197,12 @@ Doing so in a snippet allows the same set of overlays to be re-used across other
     var lc = map.layerscontrol;
 
     // An example from the Atlas of Living Australia https://www.ala.org.au/
-    lc.addOverlay(L.tileLayer.wms('https://spatial-beta.ala.org.au/geoserver/ALA/wms',
-    {
-        layers: 'ALA:11385_species_richness',
-        format: 'image/png',
-        transparent: true,
-    }),
-    'Species Richness');
+    lc.addOverlay(
+        L.tileLayer.wms(
+        'https://spatial-beta.ala.org.au/geoserver/ALA/wms',
+        {layers: 'ALA:aus2', format: 'image/png', transparent: true}),
+        'Australia'
+    );
 
     // add lc.addOverlay() layers as needed
 

--- a/docs/widget.rst
+++ b/docs/widget.rst
@@ -187,7 +187,7 @@ Every map field will trigger an event you can use to add your custom machinery :
 
 
 If you need a reusable customization of widgets maps, first override the JavaScript
-field behaviour by extending ``L.GeometryField``, then in *Django* subclass the
+field behavior by extending ``L.GeometryField``, then in *Django* subclass the
 ``LeafletWidget`` to specify the custom ``geometry_field_class``.
 
 ::

--- a/docs/widget.rst
+++ b/docs/widget.rst
@@ -82,7 +82,39 @@ some custom (non-tile) overlays.
     </script>
 
 Again, the actual overlays here are factored out into a separate snippet.
-In this example, we re-use ``shared/overlays.html`` as shown in ref::overlays_.
+In this example, we re-use ``shared/overlays.html`` as also shown in ref::overlays_.
+
+To show a textarea input for the raw GeoJSON geometry, override admin ``form_fields``:
+
+::
+    from django.contrib.gis.db import models as geo_models
+
+    LEAFLET_WIDGET_ATTRS = {
+        'map_height': '500px',
+        'map_width': '100%',
+        'display_raw': 'true',
+        'map_srid': 4326,
+    }
+
+    LEAFLET_FIELD_OPTIONS = {'widget': LeafletWidget(attrs=LEAFLET_WIDGET_ATTRS)}
+
+    FORMFIELD_OVERRIDES = {
+        geo_models.PointField: LEAFLET_FIELD_OPTIONS,
+        geo_models.MultiPointField: LEAFLET_FIELD_OPTIONS,
+        geo_models.LineStringField: LEAFLET_FIELD_OPTIONS,
+        geo_models.MultiLineStringField: LEAFLET_FIELD_OPTIONS,
+        geo_models.PolygonField: LEAFLET_FIELD_OPTIONS,
+        geo_models.MultiPolygonField: LEAFLET_FIELD_OPTIONS,
+    }
+
+    class MyAdmin(admin.ModelAdmin):
+
+        formfield_overrides = FORMFIELD_OVERRIDES
+
+
+The widget attribute `display_raw` toggles the textarea input.
+The textarea can be resized by overriding its CSS class ``.django-leaflet-raw-textarea``.
+
 
 In forms
 --------
@@ -102,6 +134,9 @@ With *Django* >= 1.6:
             model = WeatherStation
             fields = ('name', 'geom')
             widgets = {'geom': LeafletWidget()}
+
+Again, the LeafletWidget can be intialized with custom attributes,
+e.g. ``LeafletWidget(attrs=LEAFLET_WIDGET_ATTRS)`` as shown above.
 
 With all *Django* versions:
 
@@ -152,7 +187,7 @@ Every map field will trigger an event you can use to add your custom machinery :
 
 
 If you need a reusable customization of widgets maps, first override the JavaScript
-field behaviour by extending ``L.GeometryField``, then in Django subclass the
+field behaviour by extending ``L.GeometryField``, then in *Django* subclass the
 ``LeafletWidget`` to specify the custom ``geometry_field_class``.
 
 ::
@@ -177,8 +212,12 @@ field behaviour by extending ``L.GeometryField``, then in Django subclass the
             fields = ('name', 'geom')
             widgets = {'geom': YourMapWidget()}
 
-To add overlays to leaflet form widgets as shown for templates at ref::overlays_
-and for admin widets at ref::admin_, insert an extra script into the form template
+
+To customise individual forms, you can either extend the geometry field as shown above,
+or inject a script into the form template.
+
+In this example, a custom set of overlays is added as shown for both ref::overlays_
+and ref::admin_ widgets, insert an extra script into the form template
 in the same way as shown in ref::admin_.
 
 ::

--- a/leaflet/static/leaflet/leaflet.css
+++ b/leaflet/static/leaflet/leaflet.css
@@ -550,7 +550,6 @@
 
 
 /* div icon */
-
 .leaflet-div-icon {
 	background: #fff;
 	border: 1px solid #666;
@@ -634,3 +633,8 @@
 	margin-left: -12px;
 	border-right-color: #fff;
 	}
+
+/* Resize the "display_raw" textbox */
+.django-leaflet-raw-textarea {
+	width:100%;
+}

--- a/leaflet/static/leaflet/leaflet.css
+++ b/leaflet/static/leaflet/leaflet.css
@@ -636,5 +636,5 @@
 
 /* Resize the "display_raw" textbox */
 .django-leaflet-raw-textarea {
-	width:100%;
+	width: 100%;
 }

--- a/leaflet/templates/leaflet/widget.html
+++ b/leaflet/templates/leaflet/widget.html
@@ -41,5 +41,5 @@
 {% endblock map %}
 {% endif %}
 
-{% if display_raw %}<p> Geometry:</p>{% endif %}
-<textarea id="{{ id_css }}" class="required" cols="150" rows="10" name="{{ name }}">{{ serialized }}</textarea>
+{% if display_raw %}<p> Paste a valid GeoJSON Geometry:</p>{% endif %}
+<textarea id="{{ id_css }}" class="required django-leaflet-raw-textarea" cols="150" rows="10" name="{{ name }}">{{ serialized }}</textarea>

--- a/leaflet/templates/leaflet/widget.html
+++ b/leaflet/templates/leaflet/widget.html
@@ -42,6 +42,10 @@
 {% endif %}
 
 {% if display_raw %}
-<p>Draw on map or paste a <a href="http://geojsonlint.com/" title="" target="_" rel="nofollow">valid GeoJSON Geometry</a>:</p>
+<p>Draw on map or paste a <a
+    href="http://geojsonlint.com/"
+    title="Validate your GeoJSON Geometry at GeoJSONLint.com in a new window"
+    target="_"
+    rel="nofollow">valid GeoJSON Geometry</a>:</p>
 {% endif %}
 <textarea id="{{ id_css }}" class="required django-leaflet-raw-textarea" cols="150" rows="10" name="{{ name }}">{{ serialized }}</textarea>

--- a/leaflet/templates/leaflet/widget.html
+++ b/leaflet/templates/leaflet/widget.html
@@ -41,5 +41,9 @@
 {% endblock map %}
 {% endif %}
 
-{% if display_raw %}<p> Paste a valid GeoJSON Geometry:</p>{% endif %}
+{% if display_raw %}
+<p>
+    Draw on map or paste a <a href="http://geojsonlint.com/" title="" target="_" rel="nofollow">valid GeoJSON Geometry</a>:
+</p>
+{% endif %}
 <textarea id="{{ id_css }}" class="required django-leaflet-raw-textarea" cols="150" rows="10" name="{{ name }}">{{ serialized }}</textarea>

--- a/leaflet/templates/leaflet/widget.html
+++ b/leaflet/templates/leaflet/widget.html
@@ -42,8 +42,6 @@
 {% endif %}
 
 {% if display_raw %}
-<p>
-    Draw on map or paste a <a href="http://geojsonlint.com/" title="" target="_" rel="nofollow">valid GeoJSON Geometry</a>:
-</p>
+<p>Draw on map or paste a <a href="http://geojsonlint.com/" title="" target="_" rel="nofollow">valid GeoJSON Geometry</a>:</p>
 {% endif %}
 <textarea id="{{ id_css }}" class="required django-leaflet-raw-textarea" cols="150" rows="10" name="{{ name }}">{{ serialized }}</textarea>

--- a/leaflet/templates/leaflet/widget.html
+++ b/leaflet/templates/leaflet/widget.html
@@ -45,7 +45,7 @@
 <p>Draw on map or paste a <a
     href="http://geojsonlint.com/"
     title="Validate your GeoJSON Geometry at GeoJSONLint.com in a new window"
-    target="_"
+    target="_blank"
     rel="nofollow">valid GeoJSON Geometry</a>:</p>
 {% endif %}
 <textarea id="{{ id_css }}" class="required django-leaflet-raw-textarea" cols="150" rows="10" name="{{ name }}">{{ serialized }}</textarea>


### PR DESCRIPTION
Closes #247 

* Added a very long and therefore likely unique CSS class `django-leaflet-raw-textarea` to the raw textarea
* Default CSS style for `django-leaflet-raw-textarea` is width 100%
* Clarified the textarea label to specifically mention GeoJSON Geometry and added link to GeoJSONLint.com

Questions:

* Where in the docs should `display_raw` (and the resizing of the textarea) be documented?
* Should we get rid of the `cols` and `rows` attributes in the textarea?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/makinacorpus/django-leaflet/249)
<!-- Reviewable:end -->
