### PR TITLE
document consequences of configuration error

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -123,6 +123,11 @@ initial map center, default, min and max zoom level::
 
 The tuple/list must contain (lat,lng) coords.
 
+Notice that if you do not use ``SPATIAL_EXTENT``, but you do specify a value for
+the ``DEFAULT_ZOOM`` entry, you **must**  also indicate a ``DEFAULT_CENTER``,
+or you will get an empty, not working pane, for all new database records without 
+a default geometry value.  This is regarded as an error in the configuration, not
+a bug in the software.
 
 Default tiles layer
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
you could consider adding some ``console.log`` instructions, mentioning the error in the configuration, when the above happens.
or you could replace the ``DEFAULT_ZOOM`` / ``DEFAULT_CENTER`` pair with a single ``DEFAULT_VIEW`` entry, with the same shape as the parameters for ``.setView``.  gradually, obviously, through deprecation.