### PR TITLE
fix: Django 3.0 deprecation import fix

### DIFF
--- a/leaflet/__init__.py
+++ b/leaflet/__init__.py
@@ -234,4 +234,3 @@ class JSONLazyTranslationEncoder(DjangoJSONEncoder):
         if isinstance(obj, Promise):
             return force_text(obj)
         return super(JSONLazyTranslationEncoder, self).default(obj)
-

--- a/leaflet/__init__.py
+++ b/leaflet/__init__.py
@@ -18,9 +18,15 @@ except ImportError:
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.contrib.staticfiles.templatetags.staticfiles import static
+try:
+    from django.templatetags.static.static import static
+except ImportError:
+    from django.templatetags.static import static
 from django.utils.translation import ugettext_lazy as _
-from django.utils import six
+try:
+    from django.utils import six
+except ImportError:
+    import six
 import django
 
 from .utils import memoized_lazy_function, ListWithLazyItems, ListWithLazyItemsRawIterator
@@ -228,3 +234,4 @@ class JSONLazyTranslationEncoder(DjangoJSONEncoder):
         if isinstance(obj, Promise):
             return force_text(obj)
         return super(JSONLazyTranslationEncoder, self).default(obj)
+

--- a/leaflet/__init__.py
+++ b/leaflet/__init__.py
@@ -18,15 +18,19 @@ except ImportError:
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+
 try:
-    from django.templatetags.static.static import static
-except ImportError:
     from django.templatetags.static import static
-from django.utils.translation import ugettext_lazy as _
-try:
-    from django.utils import six
 except ImportError:
+    from django.contrib.staticfiles.templatetags.staticfiles import static
+
+from django.utils.translation import ugettext_lazy as _
+
+try:
     import six
+except ImportError:
+    from django.utils import six
+
 import django
 
 from .utils import memoized_lazy_function, ListWithLazyItems, ListWithLazyItemsRawIterator

--- a/leaflet/forms/backport.py
+++ b/leaflet/forms/backport.py
@@ -39,7 +39,12 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.forms.widgets import Widget
 from django.template import loader
-from django.utils import six
+
+try:
+    import six
+except ImportError:
+    from django.utils import six
+
 from django.utils import translation
 from django import forms
 from django.utils.translation import ugettext_lazy as _

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -5,10 +5,12 @@ import json
 
 from django import template
 from django.conf import settings
+
 try:
-    from django.utils import six
-except ImportError:
     import six
+except ImportError:
+    from django.utils import six
+
 from django.utils.encoding import force_text
 
 from leaflet import (app_settings, SPATIAL_EXTENT, SRID, PLUGINS, PLUGINS_DEFAULT,

--- a/leaflet/templatetags/leaflet_tags.py
+++ b/leaflet/templatetags/leaflet_tags.py
@@ -5,7 +5,10 @@ import json
 
 from django import template
 from django.conf import settings
-from django.utils import six
+try:
+    from django.utils import six
+except ImportError:
+    import six
 from django.utils.encoding import force_text
 
 from leaflet import (app_settings, SPATIAL_EXTENT, SRID, PLUGINS, PLUGINS_DEFAULT,

--- a/leaflet/tests/tests.py
+++ b/leaflet/tests/tests.py
@@ -4,14 +4,24 @@ import json
 
 import django
 from django.contrib.staticfiles.storage import StaticFilesStorage, staticfiles_storage
-from django.contrib.staticfiles.templatetags.staticfiles import static
+
+try:
+    from django.templatetags.static import static
+except ImportError:
+    from django.contrib.staticfiles.templatetags.staticfiles import static
+
 from django.test import SimpleTestCase
 from django.contrib.admin import ModelAdmin, StackedInline
 from django.contrib.admin.options import BaseModelAdmin, InlineModelAdmin
 from django.contrib.gis.db import models as gismodels
 
 from .. import PLUGINS, PLUGIN_FORMS, _normalize_plugins_config, JSONLazyTranslationEncoder
-from django.utils import six
+
+try:
+    import six
+except ImportError:
+    from django.utils import six
+
 from django.utils.translation import ugettext_lazy
 from ..templatetags import leaflet_tags
 from ..admin import LeafletGeoAdmin, LeafletGeoAdminMixin


### PR DESCRIPTION
According to [Django 3 release](https://docs.djangoproject.com/en/3.0/releases/3.0/) 
both `django.utils.six` and `django.contrib.staticfiles.templatetags.staticfiles.static()` are removed

This PR should fix ImportErrors