### PR TITLE
Bug fix: Geometry has not been displayed if geometry field name is not 'geom'

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -107,12 +107,13 @@ Initial map center and zoom level
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In addition to limiting your maps with ``SPATIAL_EXTENT``, you can also specify
-initial map center, default, min and max zoom level::
+initial map center, default, min and max zoom level, coordinate values precision::
 
     'DEFAULT_CENTER': (6.0, 45.0),
     'DEFAULT_ZOOM': 16,
     'MIN_ZOOM': 3,
     'MAX_ZOOM': 18,
+    'DEFAULT_PRECISION': 6,
 
 The tuple/list must contain (lat,lng) coords.
 

--- a/leaflet/static/leaflet/leaflet.forms.js
+++ b/leaflet/static/leaflet/leaflet.forms.js
@@ -83,7 +83,7 @@ L.FieldStore = L.Class.extend({
             return null;
         }
         // Helps to get rid of the float value conversion error
-        document.querySelector('#id_geom').value = JSON.stringify(JSON.parse(value));
+        this.formfield.value = JSON.stringify(JSON.parse(value));
         return L.GeoJSON.geometryToLayer(JSON.parse(value));
     },
 });


### PR DESCRIPTION
Fix the bug in my previous [PR](https://github.com/makinacorpus/django-leaflet/commit/d1597cfab608d555f24346cf35800e0884dcdb5a)