### PR TITLE
Update help text on map widget

### DIFF
--- a/leaflet/templates/leaflet/widget.html
+++ b/leaflet/templates/leaflet/widget.html
@@ -44,8 +44,8 @@
 
 {% if display_raw %}
 <p>Draw on map or paste a <a
-    href="http://geojsonlint.com/"
-    title="Validate your GeoJSON Geometry at GeoJSONLint.com in a new window"
+    href="https://geojson.io/"
+    title="Validate your GeoJSON Geometry at geojson.io in a new window"
     target="_blank"
     rel="nofollow">valid GeoJSON Geometry</a>:</p>
 {% endif %}


### PR DESCRIPTION
Replace link to geojsonlint.com with geojson.io. The former is monetized with clickbait-y ads, which have been reported as inappropriate for a professional environment.

In reply to https://github.com/makinacorpus/django-leaflet/issues/297#issuecomment-666285654

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/makinacorpus/django-leaflet/298)
<!-- Reviewable:end -->
