### PR TITLE
Geom field value should not be modified when deserializing its content

### DIFF
--- a/leaflet/static/leaflet/leaflet.forms.js
+++ b/leaflet/static/leaflet/leaflet.forms.js
@@ -83,8 +83,8 @@ L.FieldStore = L.Class.extend({
             return null;
         }
         // Helps to get rid of the float value conversion error
-        this.formfield.value = JSON.stringify(JSON.parse(value));
-        return L.GeoJSON.geometryToLayer(JSON.parse(value));
+        var _value = JSON.stringify(JSON.parse(value));
+        return L.GeoJSON.geometryToLayer(JSON.parse(_value));
     },
 });
 


### PR DESCRIPTION
@Zhigal you change the value of the input field when deserializing:
```
        this.formfield.value = JSON.stringify(JSON.parse(value));
```

This is a problem for me. My code does not work anymore with this change. Could you explain the rationale behind your fix ? Why de-re-serialize, why modify de DOM ?

Are you OK with this PR ?