### PR TITLE
Support Django 3.2 and drop Django 1.11, 2.0, and 2.1.

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,26 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        django_version: [ '1.11', '2.0', '2.1', '2.2', '3.0', '3.1' ]
+        django_version: [ '2.2', '3.0', '3.1', '3.2' ]
         python_version: [ '3.5', '3.6', '3.7', '3.8', '3.9' ]
         database: [ 'postgres' ]
         exclude:
-          - django_version: '1.11'
-            python_version: '3.8'
-          - django_version: '1.11'
-            python_version: '3.9'
-
-          - django_version: '2.0'
-            python_version: '3.8'
-          - django_version: '2.0'
-            python_version: '3.9'
-
-          - django_version: '2.1'
-            python_version: '3.8'
-          - django_version: '2.1'
-            python_version: '3.9'
-
           - django_version: '3.0'
+            python_version: '3.5'
+
+          - django_version: '3.1'
             python_version: '3.5'
 
           - django_version: '3.1'
@@ -82,14 +70,9 @@ jobs:
     - name: Lint with flake8
       run: |
         flake8 --ignore=E501,W504 leaflet
-    - name: Test Django >= 2.0
-      if: matrix.django_version != '1.11'
+    - name: Test
       run: |
         python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m coverage run ./quicktest.py leaflet --db=${{ matrix.database }}
-    - name: Test Django 1.11
-      if: matrix.django_version == '1.11'
-      run: |
-        python -m coverage run ./quicktest.py leaflet --db=${{ matrix.database }}
     - name: Coverage
       if: ${{ success() }}
       run: |

--- a/CHANGES
+++ b/CHANGES
@@ -6,8 +6,9 @@ CHANGELOG
 0.27.2 (unreleased)
 -------------------
 
-- Support Django 3.1.
-- tranlate to persian #313 
+- Support Django 3.1 and 3.2.
+- Drop support for Django 1.11, 2.0, and 2.1.
+- tranlate to persian #313
 
 0.27.1 (2020-07-31)
 -------------------

--- a/quicktest.py
+++ b/quicktest.py
@@ -64,6 +64,7 @@ class QuickDjangoTest:
                 'django.contrib.messages.middleware.MessageMiddleware',
                 'django.contrib.sessions.middleware.SessionMiddleware',
             ],
+            "SECRET_KEY": "insecure-secret-key",
             'TEMPLATES': [{
                 'BACKEND': 'django.template.backends.django.DjangoTemplates',
                 'OPTIONS': {
@@ -75,6 +76,8 @@ class QuickDjangoTest:
                 'APP_DIRS': True,
             }],
         }
+        if django.VERSION >= (3, 2):
+            conf["DEFAULT_AUTO_FIELD"] = "django.db.models.BigAutoField"
         if 'SPATIALITE_LIBRARY_PATH' in os.environ:
             # If you get SpatiaLite-related errors, refer to this document
             # to find out the proper SPATIALITE_LIBRARY_PATH value

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,20 @@
 [tox]
 envlist =
-    {py34,py35,py36,py37}-django111,
-    {py34,py35,py36,py37}-django20,
-    {py35,py36,py37}-django21,
-    {py35,py36,py37}-django22,
-    {py36,py37,py38}-django30,
-    {py36,py37,py38}-django31,
-    {py36,py37,py38}-djangomaster
+    {py35,py36,py37,py38,py39}-django22
+    {py36,py37,py38,py39}-django30
+    {py36,py37,py38,py39}-django31
+    {py36,py37,py38,py39}-django32
+    {py36,py37,py38,py39}-djangomain
 
 [testenv]
 commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m coverage run ./quicktest.py leaflet --db={env:DATABASE:}
 deps =
-    django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
-    django22: Django>=2.2,<3.0
-    django30: Django>=3.0,<3.1
-    django30: Django>=3.1,<3.2
-    djangomaster: https://github.com/django/django/archive/master.tar.gz
+    django22: Django~=2.2
+    django30: Django~=3.0
+    django31: Django~=3.1
+    django32: Django~=3.2
+    djangomain: https://github.com/django/django/archive/main.tar.gz
     postgres: psycopg2-binary
-    argparse
     coverage
 passenv = DATABASE SPATIALITE_LIBRARY_PATH
 


### PR DESCRIPTION
* Add to tox and travis grids.
* Add new setting.