### PR TITLE
Make 'LeafletWidget._get_attrs' a public method

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ CHANGELOG
 -------------------
 
 - Upgrade Leaflet to 1.7.1.
+- Deprecate 'LeafletWidget._get_attrs' in favor of 'LeafletWidget.get_attrs'
 
 0.28.0 (2021-04-15)
 -------------------

--- a/leaflet/forms/widgets.py
+++ b/leaflet/forms/widgets.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django import forms
 from django.contrib.gis.forms.widgets import BaseGeometryWidget
 from django.core import validators
@@ -31,6 +33,27 @@ class LeafletWidget(BaseGeometryWidget):
         return value.geojson if value else ''
 
     def _get_attrs(self, name, attrs=None):
+        """Get additional attributes for template context
+
+        Some important attributes needed for rendering the map widget
+        are not part of the widget context but rather of the global
+        template context.
+        When using e.g. :class:`django.forms.MultiWidget`, this global
+        context will not be accessible. For this reason, this method
+        has been made public so that it can be used in custom multi
+        widgets.
+
+        .. deprecated:: 0.28.1
+           Use :meth:`.get_attrs` instead.
+        """
+        warnings.warn(
+            'Method \'LeafletWidget._get_attrs\' has been deprecated. Consider calling '
+            '\'LeafletWidget.get_attrs\' instead.',
+            DeprecationWarning
+        )
+        return self.get_attrs(name, attrs=attrs)
+
+    def get_attrs(self, name, attrs=None):
         assert self.map_srid == 4326, 'Leaflet vectors should be decimal degrees.'
 
         # Retrieve params from Field init (if any)
@@ -65,5 +88,5 @@ class LeafletWidget(BaseGeometryWidget):
     def get_context(self, name, value, attrs):
         value = None if value in validators.EMPTY_VALUES else value
         context = super().get_context(name, value, attrs)
-        context.update(self._get_attrs(name, attrs))
+        context.update(self.get_attrs(name, attrs))
         return context

--- a/leaflet/tests/tests.py
+++ b/leaflet/tests/tests.py
@@ -1,3 +1,5 @@
+import warnings
+
 import django
 from django.contrib.admin import ModelAdmin, StackedInline
 from django.contrib.admin.options import BaseModelAdmin, InlineModelAdmin
@@ -134,6 +136,19 @@ class LeafletWidgetRenderingTest(SimpleTestCase):
         widget = LeafletWidget()
         widget.render('geom', '', {'id': 'geom'})
         self.assertTrue(True, 'We should\'t accept blank geometry in value.')
+
+    def test_widget_get_attrs_deprecation(self):
+        widget = LeafletWidget()
+        with self.assertWarns(DeprecationWarning):
+            priv_result = widget._get_attrs("foo")
+        pub_result = widget.get_attrs("foo")
+        self.assertEqual(
+            priv_result, pub_result,
+            msg=(
+                'Deprecated \'LeafletWidget._get_attrs\' does not have the the same '
+                'output as public method \'LeafletWidget.get_attrs\'.'
+            )
+        )
 
 
 class LeafletFieldsWidgetsTest(SimpleTestCase):


### PR DESCRIPTION
This will deprecate [`LeafletWidget._get_attrs`](https://github.com/makinacorpus/django-leaflet/blob/e9b71ae2017689767eadbfd0db682a94c2e8d3e3/leaflet/forms/widgets.py#L33) in favor of `LeafletWidget.get_attrs` for the use in e.g. [`django.forms.MultiWidget`](https://docs.djangoproject.com/en/dev/ref/forms/widgets/#django.forms.MultiWidget).

The issue of `_get_attrs` has been discussed in #322 and should be resolved by this.