### PR TITLE
fix(docs): change "action=POST" to "method=POST" in HTML snippet in docs/widget.rst

### DIFF
--- a/docs/widget.rst
+++ b/docs/widget.rst
@@ -149,7 +149,7 @@ The related template would look like this:
       </head>
       <body>
         <h1>Edit {{ object }}</h1>
-        <form action="POST">
+        <form method="POST">
             {{ form }}
             <input type="submit"/>
         </form>


### PR DESCRIPTION
**Problem**:
Original html code snippet in `docs/widget.rst`:
```
{% load leaflet_tags %}
<html>
  <head>
   {% leaflet_js plugins="forms" %}
   {% leaflet_css plugins="forms" %}
  </head>
  <body>
    <h1>Edit {{ object }}</h1>
    <form action="POST">
        {{ form }}
        <input type="submit"/>
    </form>
  </body>
</html>
```
**`POST`** is a HTML form **`method`** (and not `action`) so the above snippet does not produce a valid HTML form.

**Solution**:
I propose to change **`<form action="POST">`** to **`<form method="POST">`** in the above code snippet.