### PR TITLE
Update widget.rst

### DIFF
--- a/docs/widget.rst
+++ b/docs/widget.rst
@@ -57,6 +57,8 @@ override a custom ``admin/change_form.html``:
     {% include 'shared/leaflet_widget_overlays.js' %}
     {% endblock %}
 
+Note: Django 3.2 admin/change_form.html renamed ``stylesheet`` block to ``extrastyle`` and ``javascripts`` to ``admin_change_form_document_ready``, adjust your template accordingly.
+
 In this way, both CSS and JS can be modified for all admin leaflet widgets.
 
 As an example of modifying the CSS, here the leaflet map widget controls


### PR DESCRIPTION
It seems blocks in change_form.html have been renamed in Django 3.2 and attempt to render custom form in admin  with LeafletWidget will throw an error in console 
﻿
(index):539 Uncaught ReferenceError: L is not defined
    at loadmap ((index):539)
﻿
replacing stylesheet with extrastyle and javascripts with admin_change_form_document_ready works.