### PR TITLE
add django-geojson template filter to the documentation

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -24,6 +24,21 @@ The easy way :
 
     {% leaflet_map "yourmap" callback="window.map_init_basic" %}
 
+django-leaflet is compatible with django-geojson fields, so you can draw e.g. markers based on the `django-geojson template filter <https://django-geojson.readthedocs.io/en/latest/views.html#geojson-template-filter/>`_:
+
+::
+
+    <script>
+        function map_init_basic (map, options) {
+            ...
+            var raw_data = '{{ object_list|geojsonfeature|safe|escapejs }}';
+            var data = JSON.parse(raw_data);      
+            L.geoJSON(data).addTo(map);
+            ...
+        }
+    </script>
+
+
 
 **Using events**
 
@@ -51,7 +66,6 @@ For Internet Explorer support, we fallback on jQuery if available ::
         L.marker([50.5, 30.5]).addTo(detail.map);
         ...
     });
-
 
 Customize map size
 ------------------


### PR DESCRIPTION
Thanks for both `django-geojson` and `django-leaflet`, it's really convenient to use!

In [django-geojson](https://django-geojson.readthedocs.io/en/latest/views.html#geojson-template-filter) is stated that I can simply put 

```
// Leaflet JS
L.geoJson({{ object_list|geojsonfeature|safe}}).addTo(map);
```

to add data from my queryset to a map. However, it seems to be a [bit more complicated](https://stackoverflow.com/questions/52822561/add-geojson-to-a-leaflet-map-through-the-django-template). 

I thought it might be a good idea to contribute a working solution. If you think it is correct, we might also want to update the _django-geojson_ docs or link to this page.