### PR TITLE
Support Django 5.0 and Python 3.12, drop Python 3.8

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,28 +15,44 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        django_version: [ '3.2' , '4.0', '4.1', '4.2']
-        python_version: [ '3.7', '3.8', '3.9' , '3.10', '3.11' ]
+        django_version:
+        - '3.2'
+        - '4.0'
+        - '4.1'
+        - '4.2'
+        - '5.0'
+        python_version:
+        - '3.8'
+        - '3.9'
+        - '3.10'
+        - '3.11'
+        - '3.12'
         database: [ 'postgres' ]
         exclude:
-          - django_version: '4.0'
-            python_version: '3.7'
+          - django_version: '5.0'
+            python_version: '3.8'
 
-          - django_version: '4.1'
-            python_version: '3.7'
-
-          - django_version: '4.2'
-            python_version: '3.7'
+          - django_version: '5.0'
+            python_version: '3.9'
 
           - django_version: '3.2'
             python_version: '3.11'
 
           - django_version: '4.0'
             python_version: '3.11'
+
+          - django_version: '3.2'
+            python_version: '3.12'
+
+          - django_version: '4.0'
+            python_version: '3.12'
+
+          - django_version: '4.1'
+            python_version: '3.12'
 
         include:
           - django_version: '3.2'
-            python_version: '3.7'
+            python_version: '3.8'
             database: 'sqlite'
     env:
       SPATIALITE_LIBRARY_PATH: 'mod_spatialite'

--- a/CHANGES
+++ b/CHANGES
@@ -5,8 +5,10 @@ CHANGELOG
 0.30.0 (unreleased)
 -------------------
 
+- Support Django 5.0 and Python 3.12 (`#373 <https://github.com/makinacorpus/django-leaflet/pull/373>`__).
+- Drop support for Python 3.7 (`#373 <https://github.com/makinacorpus/django-leaflet/pull/373>`__).
 - Make django-leaflet compatible with CSP #371 (This changes the way extra CSS is handled)
-- Allow delete polygon when using multipolygon geometries #372 
+- Allow delete polygon when using multipolygon geometries #372
 
 0.29.1 (2024-03-11)
 -------------------

--- a/quicktest.py
+++ b/quicktest.py
@@ -71,6 +71,7 @@ class QuickDjangoTest:
                     'context_processors': [
                         'django.contrib.auth.context_processors.auth',
                         'django.contrib.messages.context_processors.messages',
+                        'django.template.context_processors.request',
                     ]
                 },
                 'APP_DIRS': True,

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     description="Use Leaflet in your django projects",
     long_description=long_descr,
     license='LPGL, see LICENSE file.',
+    python_requires='>=3.8',
     install_requires=requires,
     extras_require={
         'docs': ['sphinx', 'sphinx-autobuild'],
@@ -39,9 +40,10 @@ setup(
         'Framework :: Django',
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
 envlist =
-    {py37,py38,py39,py310}-django32
+    {py38,py39,py310}-django32
     {py38,py39,py310}-django40
     {py38,py39,py310,py311}-django41
-    {py38,py39,py310,py311}-django42
-    {py310,py311}-djangomain
+    {py38,py39,py310,py311,py312}-django42
+    {py310,py311,py312}-django50
+    {py310,py311,py312}-djangomain
 
 [testenv]
 commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m coverage run ./quicktest.py leaflet --db={env:DATABASE:}
@@ -13,6 +14,7 @@ deps =
     django40: Django~=4.0
     django41: Django~=4.1
     django42: Django~=4.2
+    django50: Django~=5.0
     djangomain: https://github.com/django/django/archive/main.tar.gz
     postgres: psycopg2-binary
     coverage


### PR DESCRIPTION
Copied most of the approach from 35d10aadf1faabbbe465747783e14e2075c3a137. I don’t see any new warnings on Python 3.12 + Django 5.0 when running locally.