### PR TITLE
Remove forms dependency on 'extras'

### DIFF
--- a/leaflet/__init__.py
+++ b/leaflet/__init__.py
@@ -91,7 +91,6 @@ PLUGIN_FORMS = 'forms'
 # Add plugins required for forms (not auto-included)
 # Assets will be preprended to any existing entry in PLUGINS['forms']
 _forms_js = ['leaflet/draw/leaflet.draw.js',
-             'leaflet/leaflet.extras.js',
              'leaflet/leaflet.forms.js']
 if SRID:
     _forms_js += ['leaflet/proj4.js',

--- a/leaflet/forms/widgets.py
+++ b/leaflet/forms/widgets.py
@@ -25,7 +25,11 @@ class LeafletWidget(BaseGeometryWidget):
 
         # We assume that including media for widget means there is
         # no Leaflet at all in the page.
-        js = ['leaflet/leaflet.js'] + PLUGINS[PLUGIN_FORMS]['js']
+        js = [
+            'leaflet/leaflet.js',
+            'leaflet/leaflet.extras.js',
+            *PLUGINS[PLUGIN_FORMS]['js'],
+        ]
         css = ['leaflet/leaflet.css'] + PLUGINS[PLUGIN_FORMS]['css']
         return forms.Media(js=js, css={'screen': css})
 


### PR DESCRIPTION
Refs #383. Avoid `<script src="/static/leaflet/leaflet.extras.js"></script>` being rendered twice when the `forms` plugin is requested. This also fixes the syntax error since it avoids reusing `imgPathElement`, as `leaflet.extras.js` would now only be included once.