### PR TITLE
Support Django 5.2 and Python 3.13, drop Python 3.8

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -78,7 +78,7 @@ jobs:
         sudo apt-get install -y libproj-dev libgeos-dev gdal-bin libgdal-dev
         python -m pip install --upgrade pip
         pip install -U flake8 psycopg2-binary argparse
-        pip install -U Django~=${{ matrix.django_version }}.0
+        pip install -U Django~=${{ matrix.django_version }}.0a1
     - name: Lint with flake8
       run: |
         flake8 --ignore=E501,W504 leaflet

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,6 +28,9 @@ jobs:
         - '3.13'
         database: [ 'postgres' ]
         exclude:
+          - django_version: '4.2'
+            python_version: '3.13'
+
           - django_version: '5.0'
             python_version: '3.9'
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,29 +19,30 @@ jobs:
         - '4.2'
         - '5.0'
         - '5.1'
+        - '5.2'
         python_version:
-        - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'
         - '3.12'
+        - '3.13'
         database: [ 'postgres' ]
         exclude:
           - django_version: '5.0'
-            python_version: '3.8'
-
-          - django_version: '5.0'
             python_version: '3.9'
 
-          - django_version: '5.1'
-            python_version: '3.8'
+          - django_version: '5.0'
+            python_version: '3.13'
 
           - django_version: '5.1'
+            python_version: '3.9'
+
+          - django_version: '5.2'
             python_version: '3.9'
 
         include:
           - django_version: '4.2'
-            python_version: '3.8'
+            python_version: '3.9'
             database: 'sqlite'
     env:
       SPATIALITE_LIBRARY_PATH: 'mod_spatialite'

--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,8 @@ CHANGELOG
 0.31.1 (unreleased)
 -------------------
 
--
+- Support Django 5.2 and Python 3.13 (`#388 <https://github.com/makinacorpus/django-leaflet/pull/388>`__).
+- Drop support for Python 3.8 (`#388 <https://github.com/makinacorpus/django-leaflet/pull/388>`__).
 
 0.31.0 (2024-10-14)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description="Use Leaflet in your django projects",
     long_description=long_descr,
     license='LPGL, see LICENSE file.',
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     install_requires=requires,
     extras_require={
         'docs': ['sphinx', 'sphinx-autobuild'],
@@ -40,10 +40,10 @@ setup(
         'Framework :: Django',
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist =
-    {py38,py39,py310,py311,py312}-django42
-    {py310,py311,py312}-django50
-    {py310,py311,py312}-django51
-    {py310,py311,py312}-djangomain
+    py{39,310,311,312}-django42
+    py{310,311,312}-django50
+    py{310,311,312,313}-django51
+    py{310,311,312,313}-django52
+    py{312,313}-djangomain
 
 [testenv]
 commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m coverage run ./quicktest.py leaflet --db={env:DATABASE:}
@@ -11,8 +12,8 @@ deps =
     django42: Django~=4.2
     django50: Django~=5.0
     django51: Django~=5.1
+    django52: Django~=5.2.0a1
     djangomain: https://github.com/django/django/archive/main.tar.gz
     postgres: psycopg
     coverage
 passenv = DATABASE,SPATIALITE_LIBRARY_PATH
-


### PR DESCRIPTION
5.2 is in alpha: https://www.djangoproject.com/weblog/2025/jan/16/django-52-alpha-1-released/

Python 3.13 came out in October 2024, which is also when 3.8 went EOL.

Adapted necessary changes from #373.