### PR TITLE
Don't test nonce for truthiness before inclusion

### DIFF
--- a/leaflet/templates/leaflet/_leaflet_map.html
+++ b/leaflet/templates/leaflet/_leaflet_map.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% if creatediv %}<div id="{{ name }}" class="leaflet-container-default"></div>{% endif %}
 
-<script {% if csp_nonce %}nonce="{{ csp_nonce }}"{% endif %}>
+<script nonce="{{ csp_nonce }}">
 (function () {
 
     function loadmap() {

--- a/leaflet/templates/leaflet/widget.html
+++ b/leaflet/templates/leaflet/widget.html
@@ -4,14 +4,14 @@
 {{ FORCE_IMAGE_PATH|json_script:"force-img-path" }}
 {{ reset_view_icon|json_script:"Control-ResetView-ICON" }}
 
-<style {% if csp_nonce %}nonce="{{ csp_nonce }}"{% endif %}>
+<style nonce="{{ csp_nonce }}">
     {% block map_css %}
     {% if map_width and map_height %}#{{ id_map }} { width: {{ map_width|unlocalize }}; height: {{ map_height|unlocalize }}; }{% endif %}
     {% if not display_raw %}#{{ id_css }} { display: none; }{% endif %}
     {% endblock map_css %}
 </style>
 
-<script {% if csp_nonce %}nonce="{{ csp_nonce }}"{% endif %}>
+<script nonce="{{ csp_nonce }}">
     {% block vars %}var {{ module }} = {};
     {{ module }}.fieldid = '{{ id_css }}';
     {{ module }}.modifiable = {{ modifiable|yesno:"true,false" }};


### PR DESCRIPTION
As of version 4.0 of django-csp, the behavior of the object that wraps the nonce in the request and/or context has changed.  Testing for truthiness now returns `False` instead of `True`.

The truthiness check is unnecessary anyway, skipping it is compatible with all versions of django-csp.  Probably more performant too, template rendering wise. Not that it matters.