### PR TITLE
Update license field to use proper SPDX identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     download_url="http://pypi.python.org/pypi/django-leaflet/",
     description="Use Leaflet in your django projects",
     long_description=long_descr,
-    license='LPGL, see LICENSE file.',
+    license='LGPL-3.0-or-later',
     python_requires='>=3.9',
     install_requires=requires,
     extras_require={


### PR DESCRIPTION
This changes the license field to be a valid [SPDX identifier](https://spdx.org/licenses) aligning with [PEP 639](https://peps.python.org/pep-0639/#project-source-metadata). This populates the `license_expression` field in the PyPI API and is used by downstream tools including deps.dev

This PR was generated by Claude after reviewing the license and manifest files in your repository, but opened and reviewed by me. Please let me know if the analysis is incorrect and thanks for being an OSS maintainer.