### PR TITLE
Make it clear in the documentation that the OpenStreetMap tile usage policy requires sending the referrer header

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -154,10 +154,19 @@ If it contains several layers, a layer switcher will then be added automatically
     'TILES': [('Satellite', 'http://server/a/...', {'attribution': '&copy; Big eye', 'maxZoom': 16}),
               ('Streets', 'http://server/b/...', {'attribution': '&copy; Contributors'})]
 
+OpenStreetMap requires you to set the
+`referer <https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/referrerPolicy>`_
+header on all tile requests as part of their 
+`tile usage policy <https://operations.osmfoundation.org/policies/tiles/>`_.
+Leaflet has a `mechanism to do this <https://leafletjs.com/reference.html#tilelayer-referrerpolicy>`_
+which is enabled in django-leaflet by setting ``referrerPolicy``
+as part of the ``options`` dict::
 
-If you omit this setting, a default OpenSTreetMap layer will be created for your convenience. If you do not want
-a default layers (perhaps to add them in your own JavaScript code on map initialization), set the value to an empty
-list, as shown below.
+    'TILES': [('Satellite', 'http://server/a/...', {'attribution': '...', 'referrerPolicy': 'strict-origin'}),
+
+If you omit this setting, a default OpenStreetMap layer (with ``referrerPolicy: 'strict-origin'`` will
+be created for your convenience. If you do not want any default layers (perhaps to add them in your
+own JavaScript code on map initialization), set the value to an empty list, as shown below.
 
 ::
 

--- a/leaflet/__init__.py
+++ b/leaflet/__init__.py
@@ -7,8 +7,15 @@ from django.templatetags.static import static
 from django.utils.translation import gettext_lazy as _
 from django.utils.functional import lazy, Promise
 
-DEFAULT_TILES = [(_('OSM'), '//tile.openstreetmap.org/{z}/{x}/{y}.png',
-                  '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors')]
+DEFAULT_TILES = [
+    (
+        _('OSM'), '//tile.openstreetmap.org/{z}/{x}/{y}.png',
+        {
+            'attribution': '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+            'referrerPolicy': 'strict-origin',
+        }
+    )
+]
 
 LEAFLET_CONFIG = getattr(settings, 'LEAFLET_CONFIG', {})
 app_settings = dict({


### PR DESCRIPTION
This PR changes the default tile layer configured by django-leaflet to include a sensible `referrerPolicy`, a requirement (which is now actually enforced) of the OSM [tile usage policy](https://operations.osmfoundation.org/policies/tiles/).

It also updates the documentation to urge users to set this when configuring their own tiles.

For context, you may find the PR in leaflet helpful/interesting: https://github.com/Leaflet/Leaflet/pull/9883.